### PR TITLE
:zap: define `Into<>` trait for `proto::Data`

### DIFF
--- a/src/graphql/acsys/handlers/mod.rs
+++ b/src/graphql/acsys/handlers/mod.rs
@@ -201,29 +201,6 @@ impl Mutations {
     }
 }
 
-fn xlat_type(t: &dpm::proto::Data) -> types::DataType {
-    match t.value.as_ref() {
-        Some(dpm::proto::data::Value::Scalar(v)) => {
-            types::DataType::Scalar(types::Scalar { scalar_value: *v })
-        }
-        Some(dpm::proto::data::Value::ScalarArr(v)) => {
-            types::DataType::ScalarArray(types::ScalarArray {
-                scalar_array_value: v.value.clone(),
-            })
-        }
-        Some(dpm::proto::data::Value::Status(v)) => {
-            types::DataType::StatusReply(types::StatusReply {
-                status: *v as i16,
-            })
-        }
-        Some(v) => {
-            info!("can't translate {:?}", v);
-            todo!()
-        }
-        _ => todo!(),
-    }
-}
-
 fn mk_xlater(
     names: Vec<String>,
 ) -> Box<
@@ -234,13 +211,13 @@ fn mk_xlater(
     Box::new(move |e: Result<dpm::proto::Reading, Status>| {
         let e = e.unwrap();
 
-        if let Some(ref data) = e.data {
+        if let Some(data) = e.data {
             types::DataReply {
                 ref_id: e.index as i32,
                 cycle: 1,
                 data: types::DataInfo {
                     timestamp: std::time::SystemTime::now().into(),
-                    result: xlat_type(data),
+                    result: data.into(),
                     di: 0,
                     name: names[e.index as usize].clone(),
                 },

--- a/src/graphql/acsys/handlers/types.rs
+++ b/src/graphql/acsys/handlers/types.rs
@@ -201,6 +201,10 @@ pub struct DevValue {
 // This section defines some useful traits for types in this module.
 
 use crate::g_rpc::dpm::proto;
+use tracing::warn;
+
+// Defining this trait allows us to convert a `DevValue` into a
+// `proto::Data` type by using the `.into()` method.
 
 impl Into<proto::Data> for DevValue {
     fn into(self) -> proto::Data {
@@ -279,6 +283,32 @@ impl Into<proto::Data> for DevValue {
             } => proto::Data {
                 value: Some(proto::data::Value::Raw(vec![])),
             },
+        }
+    }
+}
+
+// Defining this trait allows us to convert a `proto::Data` type into a
+// `DataType` by using the `.into()` method.
+
+impl Into<DataType> for proto::Data {
+    fn into(self) -> DataType {
+        match self.value {
+            Some(proto::data::Value::Scalar(v)) => {
+                DataType::Scalar(Scalar { scalar_value: v })
+            }
+            Some(proto::data::Value::ScalarArr(v)) => {
+                DataType::ScalarArray(ScalarArray {
+                    scalar_array_value: v.value,
+                })
+            }
+            Some(proto::data::Value::Status(v)) => {
+                DataType::StatusReply(StatusReply { status: v as i16 })
+            }
+            Some(v) => {
+                warn!("can't translate {:?}", &v);
+                todo!()
+            }
+            _ => todo!(),
         }
     }
 }


### PR DESCRIPTION
This allows us to convert a `proto::Data` into a `DataType` by using the `.into()` method. Since the method consumes the old value, we can move the internal values instead of cloning them.