### PR TITLE
Slim Dockerfile for K8s deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo build --release
 # ------------------------
 # RUN
 # ------------------------
-FROM debian:bookworm-slim
+FROM gcr.io/distroless/cc-debian12
 
 COPY --from=builder /app/target/release/extapi-dpm /usr/local/bin/extapi-dpm
 EXPOSE 8000


### PR DESCRIPTION
This PR reduces the Docker image size from 89.3MB to 38.1MB by switching to a distroless base image.