### PR TITLE
Fix the broken deployment pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # ------------------------
 FROM adregistry.fnal.gov/dev-containers/rust:1.90.0 AS builder
 
+COPY --chown=dev . /app/
 WORKDIR /app
-COPY . .
 RUN cargo build --release
 
 # ------------------------

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let incl: [&str; 0] = [];
     unsafe {
-        std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path()?)
-    };
+        std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path()?);
+    }
 
     tonic_prost_build::configure()
         .build_client(true)


### PR DESCRIPTION
The CD pipeline was failing due to "Permission denied" errors on building the executable. This was caused by the previous attempt to fix the CD pipeline, where we moved to building the executable from the dev container. The dev container has needed environment variables and tools for the app to build correctly. However, the Dockerfile was placing the code in the `/app` directory, which was being made via use of the `WORKDIR` command. `WORKDIR` can create directories, but it assigns the `ROOT` user as the owner when it does. The dev container runs as the `dev` user. The "Permission denied" error was coming from the `dev` user attempting to run code in the `/app` directory, which was owned by the `ROOT` user. Adding a `--chown=dev` flag to the `COPY` command fixes this issue. 