### PR TITLE
Add alarms snapshot

### DIFF
--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -58,6 +58,7 @@ async fn base_page() -> Html<&'static str> {
 
     <ul>
       <li><a href="/acsys">ACSys</a> (data acquisition)</li>
+      <li><a href="/alarms">Alarms</a></li>
       <li><a href="/bbm">Beam Budget monitoring</a> (WIP)</li>
       <li><a href="/devdb">Device Database</a></li>
       <li><a href="/faas">Functions as a Service</a></li>


### PR DESCRIPTION
The initial implementation of the alarms query endpoint returned an empty array. This change allows the service to grab the current "snapshot" of the alarms topic in Kafka and return all the messages. 