### PR TITLE
Use thread with timeout instead of setting env var in unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following variables exist for configuring the service at runtime:
 - `DEVDB_GRPC_HOST` -> Hostname for the DevDB gRPC service
 - `DPM_GRPC_HOST` -> Hostname for the DPM gRPC service
 - `GRAPHQL_PORT` -> Port for clients to connect via GraphQL to this service
+- `KAFKA_CONNECTION_SECONDS` -> The number of seconds to wait for a connection to Kafka before timing out
 - `KAFKA_HOST` -> Hostname for the Controls Kafka instance
 - `SCANNER_GRPC_HOST` -> Hostname for the wire scanner gRPC service
 - `TLG_GRPC_HOST` -> Hostname for the TLG gRPC service

--- a/src/g_rpc/clock/mod.rs
+++ b/src/g_rpc/clock/mod.rs
@@ -10,7 +10,7 @@ const DEFAULT_CLOCK_HOST: &str = "http://clx76.fnal.gov:6803";
 pub async fn subscribe(
     events: &[i32],
 ) -> Result<tonic::Response<tonic::Streaming<EventInfo>>, tonic::Status> {
-    let host = env_var::get(CLOCK_HOST).into_str_or(DEFAULT_CLOCK_HOST);
+    let host = env_var::get(CLOCK_HOST).or(DEFAULT_CLOCK_HOST.to_owned());
     match ClockEventClient::connect(host).await {
         Ok(mut client) => {
             let req = SubscribeReq {

--- a/src/g_rpc/devdb/mod.rs
+++ b/src/g_rpc/devdb/mod.rs
@@ -12,7 +12,7 @@ const DEFAULT_DEVDB_HOST: &str = "http://10.200.24.105:6802";
 pub async fn get_device_info(
     device: &[String],
 ) -> Result<tonic::Response<proto::DeviceInfoReply>, tonic::Status> {
-    let host = env_var::get(DEVDB_HOST).into_str_or(DEFAULT_DEVDB_HOST);
+    let host = env_var::get(DEVDB_HOST).or(DEFAULT_DEVDB_HOST.to_owned());
     match DevDbClient::connect(host).await {
         Ok(mut client) => {
             let req = proto::DeviceList {

--- a/src/g_rpc/dpm/mod.rs
+++ b/src/g_rpc/dpm/mod.rs
@@ -23,7 +23,7 @@ const DEFAULT_DPM_HOST: &str = "http://dce07.fnal.gov:50051";
 // same connection.
 
 pub async fn build_connection() -> Result<Connection, Error> {
-    let host = env_var::get(DPM_HOST).into_str_or(DEFAULT_DPM_HOST);
+    let host = env_var::get(DPM_HOST).or(DEFAULT_DPM_HOST.to_owned());
 
     Ok(Connection(DaqClient::connect(host).await?))
 }

--- a/src/g_rpc/tlg/mod.rs
+++ b/src/g_rpc/tlg/mod.rs
@@ -21,7 +21,7 @@ const DEFAULT_TLG_HOST: &str = "http://10.200.24.116:9090";
 
 async fn get_service_client(
 ) -> Result<TlgPlacementServiceClient<transport::Channel>, Status> {
-    let host = env_var::get(TLG_HOST).into_str_or(DEFAULT_TLG_HOST);
+    let host = env_var::get(TLG_HOST).or(DEFAULT_TLG_HOST.to_owned());
     TlgPlacementServiceClient::connect(host)
         .await
         .map_err(|_| Status::unavailable("TLG service unavailable"))
@@ -29,7 +29,7 @@ async fn get_service_client(
 
 async fn get_mutation_service_client(
 ) -> Result<TlgPlacementMutationServiceClient<transport::Channel>, Status> {
-    let host = env_var::get(TLG_HOST).into_str_or(DEFAULT_TLG_HOST);
+    let host = env_var::get(TLG_HOST).or(DEFAULT_TLG_HOST.to_owned());
     TlgPlacementMutationServiceClient::connect(host)
         .await
         .map_err(|_| Status::unavailable("TLG service unavailable"))

--- a/src/g_rpc/wscan/mod.rs
+++ b/src/g_rpc/wscan/mod.rs
@@ -20,8 +20,8 @@ const DEFAULT_WIRE_SCANNER_HOST: &str = "http://unknown.fnal.gov:50051";
 // Local helper function to get a connection to the gRPC service.
 
 async fn get_client() -> Result<ScannerClient<transport::Channel>, Status> {
-    let host =
-        env_var::get(WIRE_SCANNER_HOST).into_str_or(DEFAULT_WIRE_SCANNER_HOST);
+    let host = env_var::get(WIRE_SCANNER_HOST)
+        .or(DEFAULT_WIRE_SCANNER_HOST.to_owned());
     ScannerClient::connect(host)
         .await
         .map_err(|_| Status::unavailable("wire-scanner service unavailable"))

--- a/src/graphql/alarms/mod.rs
+++ b/src/graphql/alarms/mod.rs
@@ -7,7 +7,7 @@ use crate::pubsub::{Snapshot, Subscriber};
 const ALARMS_KAFKA_TOPIC: &str = "ALARMS_KAFKA_TOPIC";
 const DEFAULT_ALARMS_TOPIC: &str = "ACsys";
 fn get_topic() -> String {
-    env_var::get(ALARMS_KAFKA_TOPIC).into_str_or(DEFAULT_ALARMS_TOPIC)
+    env_var::get(ALARMS_KAFKA_TOPIC).or(DEFAULT_ALARMS_TOPIC.to_owned())
 }
 
 pub fn get_alarms_subscriber() -> Option<Subscriber> {

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -298,7 +298,7 @@ pub async fn start_service() {
     // Define the binding address for the web service. The address is
     // different between the operational and development versions.
 
-    let port = env_var::get(GQL_PORT).into_u16_or(DEFAULT_GQL_PORT);
+    let port = env_var::get(GQL_PORT).or(DEFAULT_GQL_PORT);
     let bind_addr: SocketAddr =
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), port));
 


### PR DESCRIPTION
Resolves #64 by wrapping the Kafka Consumer creation logic in a thread. The `recv_timeout` method is then utilized to wait a limited time for the connection and abort if none can be made. This is a short-circuit of the eventual timeout that the Kafka crate would reach on its own, albeit much later than the 1 second hardcoded here. 

Open question: should the timeout duration be a configurable environment variable as well?