### PR TITLE
Reconfigure pubsub to try and match the Kafka server config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,10 +2521,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = [
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 async-graphql = { version = "7", features = ["chrono"] }
 async-graphql-axum = "7"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following variables exist for configuring the service at runtime:
 - `GRAPHQL_PORT` -> Port for clients to connect via GraphQL to this service
 - `GRPC_ALARMS_DB_HOST` -> Hostname for the Alarms DB Access gRPC service
 - `KAFKA_CONNECTION_SECONDS` -> The number of seconds to wait for a connection to Kafka before timing out
+- `LOG_LEVEL` -> The maximum level for reporting log events. Can be a textual value (e.g. "ERROR", "WARN", "INFO", etc.) or numeric from 1-5 (1 = "ERROR", 5 = "TRACE")
 - `SCANNER_GRPC_HOST` -> Hostname for the wire scanner gRPC service
 - `TLG_GRPC_HOST` -> Hostname for the TLG gRPC service
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following variables exist for configuring the service at runtime:
 - `GRAPHQL_PORT` -> Port for clients to connect via GraphQL to this service
 - `GRPC_ALARMS_DB_HOST` -> Hostname for the Alarms DB Access gRPC service
 - `KAFKA_CONNECTION_SECONDS` -> The number of seconds to wait for a connection to Kafka before timing out
-- `LOG_LEVEL` -> The maximum level for reporting log events. Can be a textual value (e.g. "ERROR", "WARN", "INFO", etc.) or numeric from 1-5 (1 = "ERROR", 5 = "TRACE")
+- `RUST_LOG` -> The default logging environment variable from Rust. Can be configured to log specific crates/modules at different levels from the global default.
 - `SCANNER_GRPC_HOST` -> Hostname for the wire scanner gRPC service
 - `TLG_GRPC_HOST` -> Hostname for the TLG gRPC service
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,10 @@ mod pubsub;
 
 #[tokio::main]
 async fn main() {
+    let log_level: Level = env_var::expect("LOG_LEVEL");
     // Set up logging.
     let subscriber = tracing_subscriber::fmt()
-        .with_max_level(Level::INFO)
+        .with_max_level(log_level)
         .with_target(false)
         .with_file(true)
         .with_line_number(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
-use tracing::{info, Level};
+use tracing::{info, subscriber};
+use tracing_subscriber::{
+    filter::EnvFilter, fmt::layer, layer::SubscriberExt, Registry,
+};
 mod env_var;
 mod g_rpc;
 mod graphql;
@@ -6,16 +9,17 @@ mod pubsub;
 
 #[tokio::main]
 async fn main() {
-    let log_level: Level = env_var::expect("LOG_LEVEL");
     // Set up logging.
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(log_level)
+    let fmt_layer = layer()
         .with_target(false)
         .with_file(true)
-        .with_line_number(true)
-        .finish();
+        .with_line_number(true);
+    // The following reads the log levels specified in the RUST_LOG environment variable. Allows us to configure logging
+    // at both the application level and for specific crates/modules.
+    let level_layer = EnvFilter::from_default_env();
+    let subscriber = Registry::default().with(fmt_layer).with(level_layer);
 
-    tracing::subscriber::set_global_default(subscriber)
+    subscriber::set_global_default(subscriber)
         .expect("Unable to set global default subscriber");
 
     let _ = rustls::crypto::ring::default_provider().install_default();

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -16,6 +16,9 @@ use tokio_stream::wrappers::BroadcastStream;
 use tracing::error;
 use uuid::Uuid;
 
+const CANNED_ERR_MESSAGE: &str = "An error occurred while attempting to connect to the message broker. See server logs for details.";
+const KAFKA_CONN_SECS: &str = "KAFKA_CONNECTION_SECONDS";
+
 /// A message from the pub-sub service.
 /// Contains a key (optional) and a value.
 ///
@@ -33,32 +36,6 @@ impl Message {
     }
 }
 
-fn handle<E: Error>(result: Result<(), E>) {
-    match result {
-        Ok(_) => (),
-        Err(err) => error!("{}", err),
-    }
-}
-fn do_poll<E: Error + 'static>(
-    consumer: &mut Consumer,
-    mut append_msg: impl FnMut(Message) -> Result<(), E>,
-) -> Result<(), Box<dyn Error>> {
-    let message_sets = consumer.poll()?;
-    for set in message_sets.iter() {
-        for msg in set.messages() {
-            let key = str::from_utf8(msg.key).ok().map(String::from);
-            let value = str::from_utf8(msg.value)?.to_string();
-            append_msg(Message::new(key, value))?;
-        }
-        consumer.consume_messageset(&set)?;
-    }
-    if consumer.group().is_empty() {
-        Ok(())
-    } else {
-        Ok(consumer.commit_consumed()?)
-    }
-}
-
 struct MessageJob {
     consumer: Option<Consumer>,
     host: String,
@@ -67,6 +44,17 @@ struct MessageJob {
     uuid: Uuid,
 }
 impl MessageJob {
+    fn check_connection(&mut self) {
+        if self.consumer.is_none() {
+            self.consumer = get_consumer(
+                self.host.clone(),
+                self.topic.clone(),
+                Some(self.uuid.to_string()),
+            )
+            .ok();
+        }
+    }
+
     fn from(host: String, topic: String, sender: Arc<Sender<Message>>) -> Self {
         let uuid = Uuid::new_v4();
         Self {
@@ -80,17 +68,6 @@ impl MessageJob {
             sender,
             topic,
             uuid,
-        }
-    }
-
-    fn check_connection(&mut self) {
-        if self.consumer.is_none() {
-            self.consumer = get_consumer(
-                self.host.clone(),
-                self.topic.clone(),
-                Some(self.uuid.to_string()),
-            )
-            .ok();
         }
     }
 
@@ -121,34 +98,23 @@ impl MessageJob {
     }
 }
 
-const KAFKA_CONN_SECS: &str = "KAFKA_CONNECTION_SECONDS";
-fn get_consumer(
-    host: String, topic: String, group: Option<String>,
-) -> Result<Consumer, PubSubError> {
-    let (sender, receiver) = mpsc::channel();
-    let _ = thread::spawn(move || {
-        let consumer = Consumer::from_hosts(vec![host])
-            .with_topic(topic)
-            .with_group(group.unwrap_or_default())
-            .with_fallback_offset(FetchOffset::Earliest)
-            .with_offset_storage(Some(GroupOffsetStorage::Kafka))
-            .with_fetch_min_bytes(1)
-            .with_fetch_max_wait_time(Duration::from_millis(500))
-            .create()
-            .map_err(|err| {
-                error!("{}", err);
-                PubSubError::default()
-            });
-        handle(sender.send(consumer));
-    });
-    let connection_seconds: u64 = env_var::expect(KAFKA_CONN_SECS);
-    receiver
-        .recv_timeout(Duration::from_secs(connection_seconds))
-        .map_err(|err| {
-            error!("{}", err);
-            PubSubError::default()
-        })?
+#[derive(Debug)]
+pub struct PubSubError {
+    message: &'static str,
 }
+impl Default for PubSubError {
+    fn default() -> Self {
+        Self {
+            message: CANNED_ERR_MESSAGE,
+        }
+    }
+}
+impl fmt::Display for PubSubError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+impl Error for PubSubError {}
 
 pub struct Snapshot {
     pub data: Vec<Message>,
@@ -213,25 +179,59 @@ impl Subscriber {
     }
 }
 
-const CANNED_ERR_MESSAGE: &str = "An error occurred while attempting to connect to the message broker. See server logs for details.";
-
-#[derive(Debug)]
-pub struct PubSubError {
-    message: &'static str,
-}
-impl Default for PubSubError {
-    fn default() -> Self {
-        Self {
-            message: CANNED_ERR_MESSAGE,
+fn do_poll<E: Error + 'static>(
+    consumer: &mut Consumer,
+    mut append_msg: impl FnMut(Message) -> Result<(), E>,
+) -> Result<(), Box<dyn Error>> {
+    let message_sets = consumer.poll()?;
+    for set in message_sets.iter() {
+        for msg in set.messages() {
+            let key = str::from_utf8(msg.key).ok().map(String::from);
+            let value = str::from_utf8(msg.value)?.to_string();
+            append_msg(Message::new(key, value))?;
         }
+        consumer.consume_messageset(&set)?;
+    }
+    if consumer.group().is_empty() {
+        Ok(())
+    } else {
+        Ok(consumer.commit_consumed()?)
     }
 }
-impl fmt::Display for PubSubError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
+
+fn get_consumer(
+    host: String, topic: String, group: Option<String>,
+) -> Result<Consumer, PubSubError> {
+    let (sender, receiver) = mpsc::channel();
+    let _ = thread::spawn(move || {
+        let consumer = Consumer::from_hosts(vec![host])
+            .with_topic(topic)
+            .with_group(group.unwrap_or_default())
+            .with_fallback_offset(FetchOffset::Earliest)
+            .with_offset_storage(Some(GroupOffsetStorage::Kafka))
+            .with_fetch_max_bytes_per_partition(1048576)
+            .create()
+            .map_err(|err| {
+                error!("{}", err);
+                PubSubError::default()
+            });
+        handle(sender.send(consumer));
+    });
+    let connection_seconds: u64 = env_var::expect(KAFKA_CONN_SECS);
+    receiver
+        .recv_timeout(Duration::from_secs(connection_seconds))
+        .map_err(|err| {
+            error!("{}", err);
+            PubSubError::default()
+        })?
+}
+
+fn handle<E: Error>(result: Result<(), E>) {
+    match result {
+        Ok(_) => (),
+        Err(err) => error!("{}", err),
     }
 }
-impl std::error::Error for PubSubError {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Currently getting errors due to a misalignment with the buffer sizes of the Kafka server and the consumers in the `pubsub` crate. This is an attempt to fix that.