### PR TITLE
:sparkles: add status message field

### DIFF
--- a/src/graphql/acsys/mod.rs
+++ b/src/graphql/acsys/mod.rs
@@ -696,6 +696,7 @@ impl<'ctx> ACSysSubscriptions {
                 .map(|_| types::PlotChannelData {
                     channel_rate: "Unknown".into(),
                     channel_units: "V".into(),
+                    status_string: None,
                     channel_status: 0,
                     channel_data: vec![],
                 })
@@ -748,6 +749,7 @@ impl<'ctx> ACSysSubscriptions {
                             .map(|e| types::PlotChannelData {
                                 channel_rate: "Unknown".into(),
                                 channel_units: e.channel_units.clone(),
+                                status_string: None,
                                 channel_status: e.channel_status,
                                 channel_data: vec![],
                             })
@@ -829,6 +831,7 @@ impl<'ctx> ACSysSubscriptions {
                 .map(|_| types::PlotChannelData {
                     channel_rate: "Unknown".into(),
                     channel_units: "V".into(),
+                    status_string: None,
                     channel_status: 0,
                     channel_data: vec![],
                 })
@@ -1286,6 +1289,7 @@ mod test {
             data: vec![types::PlotChannelData {
                 channel_rate: "Unknown".into(),
                 channel_units: "V".to_owned(),
+                status_string: None,
                 channel_status: 0,
                 channel_data: POINT_DATA.to_owned(),
             }],
@@ -1349,6 +1353,7 @@ mod test {
             data: vec![types::PlotChannelData {
                 channel_rate: "Unknown".into(),
                 channel_units: "V".to_owned(),
+                status_string: None,
                 channel_status: 0,
                 channel_data: POINT_DATA.to_owned(),
             }],

--- a/src/graphql/acsys/types.rs
+++ b/src/graphql/acsys/types.rs
@@ -11,6 +11,7 @@ pub struct PlotChannelData {
 	     front-end will negotiate down to an acheivable rate. This field \
 	     represents the actual sample rate of the data."]
     pub channel_rate: String,
+    pub status_string: Option<String>,
     #[doc = "The global status of the reading. This field will either be `0` \
 	     (successful reads) or a negative status, indicating a fatal error \
 	     occurred trying to get the device's data."]


### PR DESCRIPTION
Add the status message field. Right now it will always be `null`, but at least we can release a new `flutter-controls-core` package.