### PR TITLE
Make alarms stream alarms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,6 @@ dependencies = [
  "futures-util",
  "http",
  "prost",
- "prost-types",
  "protoc-bin-vendored",
  "rdkafka",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ async-stream = "0.3"
 axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 base64 = "0.22"
-chrono = "0.4.44"
+chrono = { version = "0.4.44", features = ["serde"] }
 futures = "0.3.27"
 futures-util = { version = "0.3", features = ["tokio-io"] }
 http = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ futures = "0.3.27"
 futures-util = { version = "0.3", features = ["tokio-io"] }
 http = "1"
 prost = "0.14"
-prost-types = "0.14"
 rdkafka = { version = "0.39.0", features = ["cmake-build", "gssapi", "tracing"] }
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls", "rustls-tls-webpki-roots", "json"] }
 rustls = { version = "0.23.40", features = ["ring"] }

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_client(true)
         .build_server(false)
 	    .emit_rerun_if_changed(true)
-        .enum_attribute(".common.alarm", "#[derive(async_graphql::Enum)]")
+        .enum_attribute(".common.alarm", "#[derive(serde::Deserialize, async_graphql::Enum)]")
         .compile_protos(
             &[
                 "src/g_rpc/protos/proto/controls/common/v1/alarm.proto",

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_client(true)
         .build_server(false)
 	    .emit_rerun_if_changed(true)
-        .enum_attribute(".common.alarm", "#[derive(serde::Deserialize, async_graphql::Enum)]")
+        .compile_well_known_types(true)
+        .type_attribute(".google.protobuf.Timestamp", "#[derive(serde::Deserialize)]")
+        .type_attribute(".common.alarm", "#[derive(serde::Deserialize)]")
+        .enum_attribute(".common.alarm", "#[derive(async_graphql::Enum)]")
         .compile_protos(
             &[
                 "src/g_rpc/protos/proto/controls/common/v1/alarm.proto",

--- a/src/g_rpc/alarms_db/groups/mod.rs
+++ b/src/g_rpc/alarms_db/groups/mod.rs
@@ -4,13 +4,16 @@
 
 use crate::g_rpc::{
     alarms_db::AlarmsDbConnectionAdapter,
-    proto::services::alarms::{AlarmGroupMetadata, AlarmGroups, GroupsRequest},
+    proto::{
+        google::protobuf::Empty,
+        services::alarms::{AlarmGroupMetadata, AlarmGroups, GroupsRequest},
+    },
 };
 use tonic::{Request, Status};
 
 /// Requests all [`AlarmGroupMetadata`] from the database.
 pub async fn read_metadata(
-    request: Request<()>,
+    request: Request<Empty>,
 ) -> Result<AlarmGroupMetadata, Status> {
     let do_read = |mut client: AlarmsDbConnectionAdapter| async move {
         client.groups_conn.get_group_metadata(request).await

--- a/src/g_rpc/alarms_db/layouts/mod.rs
+++ b/src/g_rpc/alarms_db/layouts/mod.rs
@@ -3,12 +3,15 @@
 //! Provides functions for interacting with alarms user layouts.
 
 use crate::g_rpc::{
-    alarms_db::AlarmsDbConnectionAdapter, proto::services::alarms::UserLayouts,
+    alarms_db::AlarmsDbConnectionAdapter,
+    proto::{google::protobuf::Empty, services::alarms::UserLayouts},
 };
 use tonic::{Request, Status};
 
 /// Requests all [`UserLayouts`] from the database.
-pub async fn read_layouts(request: Request<()>) -> Result<UserLayouts, Status> {
+pub async fn read_layouts(
+    request: Request<Empty>,
+) -> Result<UserLayouts, Status> {
     let do_read = |mut client: AlarmsDbConnectionAdapter| async move {
         client.layouts_conn.get_user_layouts(request).await
     };

--- a/src/g_rpc/alarms_db/timers/mod.rs
+++ b/src/g_rpc/alarms_db/timers/mod.rs
@@ -4,14 +4,17 @@
 
 use crate::g_rpc::{
     alarms_db::AlarmsDbConnectionAdapter,
-    proto::services::alarms::{
-        AlarmTimer, AlarmTimers, DeleteRequest, ReadRequest,
+    proto::{
+        google::protobuf::Empty,
+        services::alarms::{
+            AlarmTimer, AlarmTimers, DeleteRequest, ReadRequest,
+        },
     },
 };
 use tonic::{Request, Status};
 
 /// Creates a new [`AlarmTimer`] in the database.
-pub async fn create(request: Request<AlarmTimer>) -> Result<(), Status> {
+pub async fn create(request: Request<AlarmTimer>) -> Result<Empty, Status> {
     let do_create = |mut client: AlarmsDbConnectionAdapter| async move {
         client.timers_conn.create(request).await
     };
@@ -19,7 +22,7 @@ pub async fn create(request: Request<AlarmTimer>) -> Result<(), Status> {
 }
 
 /// Deletes the specified [`AlarmTimer`] from the database.
-pub async fn delete(request: Request<DeleteRequest>) -> Result<(), Status> {
+pub async fn delete(request: Request<DeleteRequest>) -> Result<Empty, Status> {
     let do_delete = |mut client: AlarmsDbConnectionAdapter| async move {
         client.timers_conn.delete(request).await
     };
@@ -37,7 +40,7 @@ pub async fn read(
 }
 
 /// Updates a specified [`AlarmTimer`] with new data.
-pub async fn update(request: Request<AlarmTimer>) -> Result<(), Status> {
+pub async fn update(request: Request<AlarmTimer>) -> Result<Empty, Status> {
     let do_update = |mut client: AlarmsDbConnectionAdapter| async move {
         client.timers_conn.update(request).await
     };

--- a/src/g_rpc/alarms_svc/mod.rs
+++ b/src/g_rpc/alarms_svc/mod.rs
@@ -6,6 +6,7 @@ use crate::g_rpc::{
     connection_utils::{ConnectionAdapter, ConnectionPort},
     proto::{
         common::alarm,
+        google::protobuf::{Empty, Timestamp},
         services::alarms::{
             AcknowledgeRequest, ActivateRequest, BypassRequest,
             SnapshotResponse, SnoozeRequest,
@@ -14,7 +15,6 @@ use crate::g_rpc::{
     },
 };
 use chrono::{DateTime, Timelike, Utc};
-use prost_types::Timestamp;
 use std::sync::LazyLock;
 use tonic::{
     Response, Status, async_trait,
@@ -33,7 +33,7 @@ static ALARMS_SERVICE_CLIENT: LazyLock<
 /// Makes a request to the alarms gRPC service to acknowledge the specified alarms.
 pub async fn acknowledge_alarms(
     devices: Vec<String>, updated_by: String,
-) -> Result<(), Status> {
+) -> Result<Empty, Status> {
     let request = AcknowledgeRequest {
         devices,
         user: updated_by,
@@ -47,7 +47,7 @@ pub async fn acknowledge_alarms(
 /// Makes a request to the alarms gRPC service to activate (unbypass) the specified alarms.
 pub async fn activate_alarms(
     devices: Vec<String>, updated_by: String,
-) -> Result<(), Status> {
+) -> Result<Empty, Status> {
     let request = ActivateRequest {
         devices,
         user: updated_by,
@@ -61,7 +61,7 @@ pub async fn activate_alarms(
 /// Makes a request to the alarms gRPC service to bypass the specified alarms.
 pub async fn bypass_alarms(
     devices: Vec<String>, updated_by: String,
-) -> Result<(), Status> {
+) -> Result<Empty, Status> {
     let request = BypassRequest {
         devices,
         user: updated_by,
@@ -83,7 +83,7 @@ pub async fn get_snapshot() -> Result<Vec<alarm::Status>, Status> {
 /// Makes a request to the alarms gRPC service to snooze the specified alarms until the provided wake time.
 pub async fn snooze_alarms(
     devices: Vec<String>, updated_by: String, wake: DateTime<Utc>,
-) -> Result<(), Status> {
+) -> Result<Empty, Status> {
     let request = SnoozeRequest {
         devices,
         user: updated_by,
@@ -101,7 +101,7 @@ pub async fn snooze_alarms(
 async fn do_snapshot_request(
     mut client: AlarmsServiceConnectionAdapter,
 ) -> Result<Response<SnapshotResponse>, Status> {
-    client.conn.get_snapshot(()).await
+    client.conn.get_snapshot(Empty {}).await
 }
 
 /// An implementation of [`ConnectionAdapter`] to hold the [`AlarmCommandsClient`] reference.

--- a/src/g_rpc/mod.rs
+++ b/src/g_rpc/mod.rs
@@ -17,6 +17,12 @@ pub mod proto {
         }
     }
 
+    pub mod google {
+        pub mod protobuf {
+            tonic::include_proto!("google.protobuf");
+        }
+    }
+
     pub mod services {
         pub mod aclk {
             tonic::include_proto!("services.clock_event");

--- a/src/g_rpc/tlg/mod.rs
+++ b/src/g_rpc/tlg/mod.rs
@@ -1,5 +1,7 @@
 //! Timeline Generator gRPC Module
 
+use crate::g_rpc::proto::google::protobuf::Empty;
+
 use super::proto::services::tlg_placement::{
     TlgDevices, TlgPlacementResponse,
     tlg_placement_mutation_service_client::TlgPlacementMutationServiceClient,
@@ -31,7 +33,7 @@ async fn get_mutation_service_client()
 pub async fn get_version() -> Result<String, Status> {
     get_service_client()
         .await?
-        .get_version(())
+        .get_version(Empty {})
         .await
         .map(|v| v.into_inner().version)
 }

--- a/src/graphql/alarms/mod.rs
+++ b/src/graphql/alarms/mod.rs
@@ -5,12 +5,12 @@
 use crate::{
     g_rpc::{alarms_db, alarms_svc, proto::services::alarms},
     graphql::alarms::types::Alarm,
-    pubsub::{Message, Subscriber, kafka_impl::KafkaSubscriber},
+    pubsub::{Subscriber, kafka_impl::KafkaSubscriber},
 };
 use async_graphql::{Error, Object, Subscription};
 use chrono::{DateTime, Utc};
 use rust_env_var_lib::env_var;
-use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::{Stream, StreamExt};
 use tonic::{Code, Request, Status};
 use tracing::error;
 use types::{AlarmGroup, AlarmGroupMetadatum, AlarmTimer, UserLayout};
@@ -221,9 +221,20 @@ pub struct AlarmsSubscriptions;
 #[Subscription]
 impl AlarmsSubscriptions {
     /// Streams back all alarms from the alarms topic.
-    async fn alarms(&self) -> Result<BroadcastStream<Message>, Error> {
+    async fn alarms(&self) -> Result<impl Stream<Item = Alarm>, Error> {
         KafkaSubscriber::subscribe(get_host(), get_topic())
             .await
+            .map(|stream| {
+                stream.filter_map(|stream_item| match stream_item {
+                    Err(e) => {
+                        error!("{e:?}");
+                        None
+                    }
+                    Ok(message) => Alarm::try_from(message)
+                        .inspect_err(|e| error!("{e:?}"))
+                        .ok(),
+                })
+            })
             .map_err(|e| Error::new(format!("{e}")))
     }
 }

--- a/src/graphql/alarms/mod.rs
+++ b/src/graphql/alarms/mod.rs
@@ -3,7 +3,10 @@
 //! Provides the query implementations for the Alarms GraphQL interface.
 
 use crate::{
-    g_rpc::{alarms_db, alarms_svc, proto::services::alarms},
+    g_rpc::{
+        alarms_db, alarms_svc,
+        proto::{google::protobuf::Empty, services::alarms},
+    },
     graphql::alarms::types::Alarm,
     pubsub::{Subscriber, kafka_impl::KafkaSubscriber},
 };
@@ -134,7 +137,7 @@ impl AlarmsQueries {
     async fn alarms_group_metadata(
         &self,
     ) -> Result<Vec<AlarmGroupMetadatum>, Error> {
-        match alarms_db::groups::read_metadata(Request::new(())).await {
+        match alarms_db::groups::read_metadata(Request::new(Empty {})).await {
             Ok(response) => {
                 let mapped_response = response
                     .metadata
@@ -170,7 +173,7 @@ impl AlarmsQueries {
 
     /// Reads all [`UserLayout`]s in the database.
     async fn alarms_user_layouts(&self) -> Result<Vec<UserLayout>, Error> {
-        match alarms_db::layouts::read_layouts(Request::new(())).await {
+        match alarms_db::layouts::read_layouts(Request::new(Empty {})).await {
             Ok(response) => {
                 let mapped_response = response
                     .layouts

--- a/src/graphql/alarms/types.rs
+++ b/src/graphql/alarms/types.rs
@@ -15,11 +15,15 @@ use crate::{
         },
     },
     graphql::alarms::utils,
+    pubsub::Message,
 };
 use async_graphql::SimpleObject;
 use chrono::{DateTime, Utc};
 
-#[derive(Clone, Debug, PartialEq, SimpleObject)]
+#[cfg(test)]
+mod tests;
+
+#[derive(Clone, Debug, serde::Deserialize, PartialEq, SimpleObject)]
 pub struct Alarm {
     pub device: String,
     pub source: Source,
@@ -48,6 +52,14 @@ impl From<Status> for Alarm {
             user: value.user,
             wake: utils::timestamp_to_datetime(value.wake),
         }
+    }
+}
+
+impl TryFrom<Message> for Alarm {
+    type Error = serde_json::Error;
+
+    fn try_from(value: Message) -> Result<Self, Self::Error> {
+        serde_json::from_str(&value.value)
     }
 }
 
@@ -122,151 +134,5 @@ impl From<ProtoUserLayout> for UserLayout {
             user_name: value.user_name,
             groups: value.groups,
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::g_rpc::proto::services::alarms::TimerType;
-    use prost_types::Timestamp;
-
-    #[test]
-    fn alarm_from_proto_to_gql() {
-        let status = Status {
-            device: "M:BEAM".to_string(),
-            source: Source::Analog as i32,
-            state: State::Ok as i32,
-            severity: Severity::Unknown as i32,
-            acknowledgeable: false,
-            time: utils::datetime_to_timestamp(Some(Utc::now())),
-            epics_type: String::new(),
-            user: "test user".to_string(),
-            wake: None,
-        };
-
-        let output = Alarm::from(status.clone());
-
-        assert_eq!(status.device, output.device);
-        assert_eq!(status.source(), output.source);
-        assert_eq!(status.state(), output.state);
-        assert_eq!(status.severity(), output.severity);
-        assert_eq!(status.acknowledgeable, output.acknowledgeable);
-        assert_eq!(status.time, utils::datetime_to_timestamp(output.time));
-        assert_eq!(status.epics_type, output.epics_type);
-        assert_eq!(status.user, output.user);
-        assert_eq!(status.wake, utils::datetime_to_timestamp(output.wake));
-    }
-
-    #[test]
-    fn group_from_proto_to_gql() {
-        let test_name = "device A";
-        let test_desc = "desc";
-        let test_seconds = 100;
-        let test_nanos = 3242;
-        let test_user = "user 1";
-        let proto_meta = ProtoGroupMetadatum {
-            name: test_name.to_string(),
-            description: test_desc.to_string(),
-            is_user_category: true,
-            updated_at: Some(Timestamp {
-                seconds: test_seconds,
-                nanos: test_nanos,
-            }),
-            updated_by: test_user.to_string(),
-        };
-        let test_devices =
-            vec![String::from("device 1"), String::from("device 2")];
-        let test_groups = vec![String::from("group 1")];
-        let proto = ProtoAlarmGroup {
-            metadata: Some(proto_meta.clone()),
-            devices: test_devices.clone(),
-            groups: test_groups.clone(),
-        };
-
-        let result = AlarmGroup::from(proto);
-
-        assert_eq!(result.devices, test_devices);
-        assert_eq!(result.groups, test_groups);
-        assert_eq!(
-            result.metadata.unwrap(),
-            AlarmGroupMetadatum::from(proto_meta)
-        );
-    }
-
-    #[test]
-    fn metadatum_from_proto_to_gql() {
-        let test_name = "device A";
-        let test_desc = "desc";
-        let test_seconds = 100;
-        let test_nanos = 3242;
-        let test_user = "user 1";
-        let proto = ProtoGroupMetadatum {
-            name: test_name.to_string(),
-            description: test_desc.to_string(),
-            is_user_category: true,
-            updated_at: Some(Timestamp {
-                seconds: test_seconds,
-                nanos: test_nanos,
-            }),
-            updated_by: test_user.to_string(),
-        };
-
-        let result = AlarmGroupMetadatum::from(proto);
-
-        assert_eq!(result.name, test_name);
-        assert_eq!(result.description, test_desc);
-        assert!(result.is_user_category);
-        assert_eq!(
-            result.updated_at,
-            DateTime::from_timestamp(test_seconds, test_nanos as u32)
-        );
-        assert_eq!(result.updated_by, test_user);
-    }
-
-    #[test]
-    fn timer_from_proto_to_gql() {
-        let test_device = "device A";
-        let test_seconds = 100;
-        let test_nanos = 3242;
-        let test_user = "user 1";
-        let proto = ProtoAlarmTimer {
-            device: test_device.to_string(),
-            end_time: Some(Timestamp {
-                seconds: test_seconds,
-                nanos: test_nanos,
-            }),
-            timer_type: TimerType::BypassReminder as i32,
-            updated_at: None,
-            updated_by: test_user.to_string(),
-        };
-
-        let result = AlarmTimer::from(proto);
-
-        assert_eq!(result.device, test_device);
-        assert_eq!(
-            result.end_time,
-            DateTime::from_timestamp(test_seconds, test_nanos as u32)
-        );
-        assert_eq!(result.timer_type, TimerType::BypassReminder.as_str_name());
-        assert_eq!(result.updated_at, None);
-        assert_eq!(result.updated_by, test_user);
-    }
-
-    #[test]
-    fn user_layout_from_proto_to_gql() {
-        let test_user = "user1";
-        let grp1 = "group 1";
-        let grp2 = "group 2";
-        let test_groups = vec![grp1.to_string(), grp2.to_string()];
-        let proto_layout = ProtoUserLayout {
-            user_name: test_user.to_string(),
-            groups: test_groups.clone(),
-        };
-
-        let result = UserLayout::from(proto_layout);
-
-        assert_eq!(result.user_name, test_user);
-        assert_eq!(result.groups, test_groups);
     }
 }

--- a/src/graphql/alarms/types.rs
+++ b/src/graphql/alarms/types.rs
@@ -23,7 +23,7 @@ use chrono::{DateTime, Utc};
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone, Debug, serde::Deserialize, PartialEq, SimpleObject)]
+#[derive(Clone, Debug, PartialEq, SimpleObject)]
 pub struct Alarm {
     pub device: String,
     pub source: Source,
@@ -59,7 +59,7 @@ impl TryFrom<Message> for Alarm {
     type Error = serde_json::Error;
 
     fn try_from(value: Message) -> Result<Self, Self::Error> {
-        serde_json::from_str(&value.value)
+        serde_json::from_str::<Status>(&value.value).map(Alarm::from)
     }
 }
 

--- a/src/graphql/alarms/types/tests.rs
+++ b/src/graphql/alarms/types/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
-use crate::g_rpc::proto::services::alarms::TimerType;
-use prost_types::Timestamp;
+use crate::g_rpc::proto::{
+    google::protobuf::Timestamp, services::alarms::TimerType,
+};
 
 #[test]
 fn alarm_from_proto_to_gql() {
@@ -31,17 +32,22 @@ fn alarm_from_proto_to_gql() {
 
 #[test]
 fn alarm_try_from_message() {
-    let text = r#"
-        {
-            "device": "M:BEAM",
-            "source": "Analog",
-            "state": "Ok",
-            "severity": "Unknown",
-            "acknowledgeable": false,
-            "epics_type": "",
-            "user": ""
-        }
-    "#;
+    let source_int = Source::Analog as i32;
+    let state_int = State::Ok as i32;
+    let severity_int = Severity::Unknown as i32;
+    let text = format!(
+        r#"
+            {{
+                "device": "M:BEAM",
+                "source": {source_int},
+                "state": {state_int},
+                "severity": {severity_int},
+                "acknowledgeable": false,
+                "epics_type": "",
+                "user": ""
+            }}
+        "#
+    );
     let message = Message::new(None, text.to_string());
 
     let output = Alarm::try_from(message).unwrap();

--- a/src/graphql/alarms/types/tests.rs
+++ b/src/graphql/alarms/types/tests.rs
@@ -1,0 +1,168 @@
+use super::*;
+use crate::g_rpc::proto::services::alarms::TimerType;
+use prost_types::Timestamp;
+
+#[test]
+fn alarm_from_proto_to_gql() {
+    let status = Status {
+        device: "M:BEAM".to_string(),
+        source: Source::Analog as i32,
+        state: State::Ok as i32,
+        severity: Severity::Unknown as i32,
+        acknowledgeable: false,
+        time: utils::datetime_to_timestamp(Some(Utc::now())),
+        epics_type: String::new(),
+        user: "test user".to_string(),
+        wake: None,
+    };
+
+    let output = Alarm::from(status.clone());
+
+    assert_eq!(status.device, output.device);
+    assert_eq!(status.source(), output.source);
+    assert_eq!(status.state(), output.state);
+    assert_eq!(status.severity(), output.severity);
+    assert_eq!(status.acknowledgeable, output.acknowledgeable);
+    assert_eq!(status.time, utils::datetime_to_timestamp(output.time));
+    assert_eq!(status.epics_type, output.epics_type);
+    assert_eq!(status.user, output.user);
+    assert_eq!(status.wake, utils::datetime_to_timestamp(output.wake));
+}
+
+#[test]
+fn alarm_try_from_message() {
+    let text = r#"
+        {
+            "device": "M:BEAM",
+            "source": "Analog",
+            "state": "Ok",
+            "severity": "Unknown",
+            "acknowledgeable": false,
+            "epics_type": "",
+            "user": ""
+        }
+    "#;
+    let message = Message::new(None, text.to_string());
+
+    let output = Alarm::try_from(message).unwrap();
+    assert_eq!(output.device, "M:BEAM");
+    assert_eq!(output.source, Source::Analog);
+    assert_eq!(output.state, State::Ok);
+    assert_eq!(output.severity, Severity::Unknown);
+    assert!(!output.acknowledgeable);
+    assert_eq!(output.time, None);
+    assert_eq!(output.epics_type, "");
+    assert_eq!(output.user, "");
+    assert_eq!(output.wake, None);
+}
+
+#[test]
+fn group_from_proto_to_gql() {
+    let test_name = "device A";
+    let test_desc = "desc";
+    let test_seconds = 100;
+    let test_nanos = 3242;
+    let test_user = "user 1";
+    let proto_meta = ProtoGroupMetadatum {
+        name: test_name.to_string(),
+        description: test_desc.to_string(),
+        is_user_category: true,
+        updated_at: Some(Timestamp {
+            seconds: test_seconds,
+            nanos: test_nanos,
+        }),
+        updated_by: test_user.to_string(),
+    };
+    let test_devices = vec![String::from("device 1"), String::from("device 2")];
+    let test_groups = vec![String::from("group 1")];
+    let proto = ProtoAlarmGroup {
+        metadata: Some(proto_meta.clone()),
+        devices: test_devices.clone(),
+        groups: test_groups.clone(),
+    };
+
+    let result = AlarmGroup::from(proto);
+
+    assert_eq!(result.devices, test_devices);
+    assert_eq!(result.groups, test_groups);
+    assert_eq!(
+        result.metadata.unwrap(),
+        AlarmGroupMetadatum::from(proto_meta)
+    );
+}
+
+#[test]
+fn metadatum_from_proto_to_gql() {
+    let test_name = "device A";
+    let test_desc = "desc";
+    let test_seconds = 100;
+    let test_nanos = 3242;
+    let test_user = "user 1";
+    let proto = ProtoGroupMetadatum {
+        name: test_name.to_string(),
+        description: test_desc.to_string(),
+        is_user_category: true,
+        updated_at: Some(Timestamp {
+            seconds: test_seconds,
+            nanos: test_nanos,
+        }),
+        updated_by: test_user.to_string(),
+    };
+
+    let result = AlarmGroupMetadatum::from(proto);
+
+    assert_eq!(result.name, test_name);
+    assert_eq!(result.description, test_desc);
+    assert!(result.is_user_category);
+    assert_eq!(
+        result.updated_at,
+        DateTime::from_timestamp(test_seconds, test_nanos as u32)
+    );
+    assert_eq!(result.updated_by, test_user);
+}
+
+#[test]
+fn timer_from_proto_to_gql() {
+    let test_device = "device A";
+    let test_seconds = 100;
+    let test_nanos = 3242;
+    let test_user = "user 1";
+    let proto = ProtoAlarmTimer {
+        device: test_device.to_string(),
+        end_time: Some(Timestamp {
+            seconds: test_seconds,
+            nanos: test_nanos,
+        }),
+        timer_type: TimerType::BypassReminder as i32,
+        updated_at: None,
+        updated_by: test_user.to_string(),
+    };
+
+    let result = AlarmTimer::from(proto);
+
+    assert_eq!(result.device, test_device);
+    assert_eq!(
+        result.end_time,
+        DateTime::from_timestamp(test_seconds, test_nanos as u32)
+    );
+    assert_eq!(result.timer_type, TimerType::BypassReminder.as_str_name());
+    assert_eq!(result.updated_at, None);
+    assert_eq!(result.updated_by, test_user);
+}
+
+#[test]
+fn user_layout_from_proto_to_gql() {
+    let test_user = "user1";
+    let grp1 = "group 1";
+    let grp2 = "group 2";
+    let test_groups = vec![grp1.to_string(), grp2.to_string()];
+    let proto_layout = ProtoUserLayout {
+        user_name: test_user.to_string(),
+        groups: test_groups.clone(),
+    };
+
+    let result = UserLayout::from(proto_layout);
+
+    assert_eq!(result.user_name, test_user);
+    assert_eq!(result.groups, test_groups);
+}

--- a/src/graphql/alarms/utils.rs
+++ b/src/graphql/alarms/utils.rs
@@ -2,9 +2,9 @@
 //!
 //! Provides various utility functions that are useful in the context of alarms.
 
+use crate::g_rpc::proto::google::protobuf::Timestamp;
 use crate::g_rpc::proto::services::alarms::TimerType;
 use chrono::{DateTime, Timelike, Utc};
-use prost_types::Timestamp;
 
 pub fn datetime_to_timestamp(
     datetime: Option<DateTime<Utc>>,


### PR DESCRIPTION
## Replace `prost-types` with compiled well-known types; deliver typed alarm streaming

### What changed and why

This PR does two related things that share a root cause: we needed `serde::Deserialize` on `google.protobuf.Timestamp`, and `prost-types::Timestamp` doesn't give us that.

**1. Drop `prost-types`, compile `google.protobuf` well-known types directly**

We were using `prost-types` solely for `Timestamp`. To add `serde` deserialization support to it — needed for deserializing Kafka alarm messages — we'd have had to patch an external crate. The cleaner path: tell `tonic-build` to [`compile_well_known_types(true)`](build.rs:47), expose the result at [`g_rpc::proto::google::protobuf`](src/g_rpc/mod.rs:214), and derive [`serde::Deserialize`](build.rs:48) on it directly via a `type_attribute`. Now `Timestamp` is ours to annotate, `prost-types` is gone from [`Cargo.toml`](Cargo.toml:35), and there's one fewer dependency to keep in sync.

As a side effect, every call site that passed `()` as a gRPC request body now passes [`Empty {}`](src/g_rpc/alarms_svc/mod.rs:202) — the actual protobuf well-known type — which is what the generated client stubs expect.

**2. Add `serde` support to `chrono` and the alarm proto types**

Enabling [`chrono`'s `serde` feature](Cargo.toml:30) and deriving [`serde::Deserialize`](build.rs:48) on `google.protobuf.Timestamp` and `common.alarm` unlocks JSON deserialization of alarm messages coming off the Kafka topic. This is the prerequisite for the next change.

**3. Make the `alarms` subscription deliver typed `Alarm` objects**

Previously the subscription returned a raw [`BroadcastStream<Message>`](src/graphql/alarms/mod.rs:291) — the GraphQL client received whatever bytes came off the wire. Now it returns [`impl Stream<Item = Alarm>`](src/graphql/alarms/mod.rs:292). The stream deserializes each Kafka message into a [`Status`](src/graphql/alarms/types.rs:336) proto, converts it to an [`Alarm`](src/graphql/alarms/types.rs:326) GraphQL type, and filters out anything that fails to parse (logging the error). Clients get a strongly-typed stream; malformed messages are dropped gracefully rather than crashing the subscription.

The new [`TryFrom<Message> for Alarm`](src/graphql/alarms/types.rs:332) impl is the seam that makes this testable in isolation.

**4. Move tests to their own file**

The inline `mod test` block in [`types.rs`](src/graphql/alarms/types.rs) was getting long. It now lives in [`src/graphql/alarms/types/tests.rs`](src/graphql/alarms/types/tests.rs). The tests themselves are unchanged except for one addition: [`alarm_try_from_message`](src/graphql/alarms/types/tests.rs:532) exercises the new deserialization path end-to-end with a JSON fixture, confirming that optional fields (`time`, `wake`) deserialize to `None` when absent.

### The tests tell the story

The test suite now covers the full path from raw Kafka message bytes → `Alarm` GraphQL type. If you want to understand what the system does with an alarm message, read [`alarm_try_from_message`](src/graphql/alarms/types/tests.rs:532) first. The other tests (`alarm_from_proto_to_gql`, `group_from_proto_to_gql`, `metadatum_from_proto_to_gql`, `timer_from_proto_to_gql`, `user_layout_from_proto_to_gql`) remain as a safety net for the proto→GraphQL conversions.

### What this is not

This is not a change to the alarm data model, the GraphQL schema shape, or the Kafka topic configuration. Existing clients will see the same fields; they just arrive typed rather than raw.