### PR TITLE
Move alarms proto details to g_rpc module

### DIFF
--- a/src/g_rpc/alarms_db/groups/mod.rs
+++ b/src/g_rpc/alarms_db/groups/mod.rs
@@ -9,24 +9,28 @@ use crate::g_rpc::{
         services::alarms::{AlarmGroupMetadata, AlarmGroups, GroupsRequest},
     },
 };
-use tonic::{Request, Status};
+use tonic::{Response, Status};
 
 /// Requests all [`AlarmGroupMetadata`] from the database.
-pub async fn read_metadata(
-    request: Request<Empty>,
-) -> Result<AlarmGroupMetadata, Status> {
+pub async fn read_metadata() -> Result<AlarmGroupMetadata, Status> {
+    super::ALARMS_DB_CLIENT
+        .run_with_client(get_group_metadata)
+        .await
+}
+
+/// Requests the [`AlarmGroups`] data for the specified groups from the database.
+pub async fn read_groups(groups: Vec<String>) -> Result<AlarmGroups, Status> {
     let do_read = |mut client: AlarmsDbConnectionAdapter| async move {
-        client.groups_conn.get_group_metadata(request).await
+        client
+            .groups_conn
+            .get_groups(GroupsRequest { groups })
+            .await
     };
     super::ALARMS_DB_CLIENT.run_with_client(do_read).await
 }
 
-/// Requests the [`AlarmGroups`] data for the specified groups from the database.
-pub async fn read_groups(
-    request: Request<GroupsRequest>,
-) -> Result<AlarmGroups, Status> {
-    let do_read = |mut client: AlarmsDbConnectionAdapter| async move {
-        client.groups_conn.get_groups(request).await
-    };
-    super::ALARMS_DB_CLIENT.run_with_client(do_read).await
+async fn get_group_metadata(
+    mut client: AlarmsDbConnectionAdapter,
+) -> Result<Response<AlarmGroupMetadata>, Status> {
+    client.groups_conn.get_group_metadata(Empty {}).await
 }

--- a/src/g_rpc/alarms_db/layouts/mod.rs
+++ b/src/g_rpc/alarms_db/layouts/mod.rs
@@ -6,14 +6,19 @@ use crate::g_rpc::{
     alarms_db::AlarmsDbConnectionAdapter,
     proto::{google::protobuf::Empty, services::alarms::UserLayouts},
 };
-use tonic::{Request, Status};
+use tonic::{Response, Status};
 
 /// Requests all [`UserLayouts`] from the database.
-pub async fn read_layouts(
-    request: Request<Empty>,
-) -> Result<UserLayouts, Status> {
-    let do_read = |mut client: AlarmsDbConnectionAdapter| async move {
-        client.layouts_conn.get_user_layouts(request).await
-    };
-    super::ALARMS_DB_CLIENT.run_with_client(do_read).await
+pub async fn read_layouts() -> Result<UserLayouts, Status> {
+    super::ALARMS_DB_CLIENT
+        .run_with_client(get_user_layouts)
+        .await
+}
+
+// Named function (rather than a closure) so it can be passed directly
+// to `run_with_client` without capturing.
+async fn get_user_layouts(
+    mut client: AlarmsDbConnectionAdapter,
+) -> Result<Response<UserLayouts>, Status> {
+    client.layouts_conn.get_user_layouts(Empty {}).await
 }

--- a/src/g_rpc/alarms_db/timers/mod.rs
+++ b/src/g_rpc/alarms_db/timers/mod.rs
@@ -5,44 +5,149 @@
 use crate::g_rpc::{
     alarms_db::AlarmsDbConnectionAdapter,
     proto::{
-        google::protobuf::Empty,
+        google::protobuf::{Empty, Timestamp},
         services::alarms::{
-            AlarmTimer, AlarmTimers, DeleteRequest, ReadRequest,
+            AlarmTimer, AlarmTimers, DeleteRequest, ReadRequest, TimerType,
         },
     },
 };
-use tonic::{Request, Status};
+use chrono::{DateTime, Timelike, Utc};
+use tonic::Status;
 
 /// Creates a new [`AlarmTimer`] in the database.
-pub async fn create(request: Request<AlarmTimer>) -> Result<Empty, Status> {
-    let do_create = |mut client: AlarmsDbConnectionAdapter| async move {
-        client.timers_conn.create(request).await
+///
+/// `timer_type` must be a valid [`TimerType`] protobuf enum name
+/// (e.g. `"TimerType_SNOOZE"`). Unrecognised values are silently
+/// treated as [`TimerType::Unknown`].
+///
+/// `updated_at` is set to the current UTC time at the call site.
+///
+/// Returns the created [`AlarmTimer`] as submitted (the server
+/// responds with `Empty`; no server-side fields are reflected back).
+pub async fn create(
+    device: String, end_time: Option<DateTime<Utc>>, timer_type: String,
+    updated_by: String,
+) -> Result<AlarmTimer, Status> {
+    let timer = AlarmTimer {
+        device,
+        end_time: datetime_to_timestamp(end_time),
+        timer_type: string_to_timer_type(&timer_type) as i32,
+        updated_at: datetime_to_timestamp(Some(Utc::now())),
+        updated_by,
     };
-    super::ALARMS_DB_CLIENT.run_with_client(do_create).await
+    let returned_copy = timer.clone();
+    let do_create = |mut client: AlarmsDbConnectionAdapter| async move {
+        client.timers_conn.create(timer).await
+    };
+    super::ALARMS_DB_CLIENT
+        .run_with_client(do_create)
+        .await
+        .map(|_| returned_copy)
 }
 
 /// Deletes the specified [`AlarmTimer`] from the database.
-pub async fn delete(request: Request<DeleteRequest>) -> Result<Empty, Status> {
+///
+/// `timer_type` must be a valid [`TimerType`] protobuf enum name
+/// (e.g. `"TimerType_SNOOZE"`). Unrecognised values are silently
+/// treated as [`TimerType::Unknown`].
+pub async fn delete(
+    device: String, timer_type: String,
+) -> Result<Empty, Status> {
+    let request = DeleteRequest {
+        device,
+        timer_type: string_to_timer_type(&timer_type) as i32,
+    };
     let do_delete = |mut client: AlarmsDbConnectionAdapter| async move {
         client.timers_conn.delete(request).await
     };
     super::ALARMS_DB_CLIENT.run_with_client(do_delete).await
 }
 
-/// Reads all [`AlarmTimers`] of the specified [`TimerType`](crate::g_rpc::proto::services::alarms::TimerType) for a given user.
+/// Reads all [`AlarmTimers`] of the specified [`TimerType`] for a given user.
 pub async fn read(
-    request: Request<ReadRequest>,
+    timer_type: String, user: String,
 ) -> Result<AlarmTimers, Status> {
+    let request = ReadRequest {
+        timer_type: string_to_timer_type(&timer_type) as i32,
+        user,
+    };
     let do_read = |mut client: AlarmsDbConnectionAdapter| async move {
         client.timers_conn.read(request).await
     };
     super::ALARMS_DB_CLIENT.run_with_client(do_read).await
 }
 
-/// Updates a specified [`AlarmTimer`] with new data.
-pub async fn update(request: Request<AlarmTimer>) -> Result<Empty, Status> {
-    let do_update = |mut client: AlarmsDbConnectionAdapter| async move {
-        client.timers_conn.update(request).await
+/// Updates an [`AlarmTimer`] in the database.
+///
+/// `timer_type` must be a valid [`TimerType`] protobuf enum name
+/// (e.g. `"TimerType_SNOOZE"`). Unrecognised values are silently
+/// treated as [`TimerType::Unknown`].
+///
+/// `updated_at` is set to the current UTC time at the call site.
+///
+/// Returns the updated [`AlarmTimer`] as submitted (the server
+/// responds with `Empty`; no server-side fields are reflected back).
+pub async fn update(
+    device: String, end_time: Option<DateTime<Utc>>, timer_type: String,
+    updated_by: String,
+) -> Result<AlarmTimer, Status> {
+    let timer = AlarmTimer {
+        device,
+        end_time: datetime_to_timestamp(end_time),
+        timer_type: string_to_timer_type(&timer_type) as i32,
+        updated_at: datetime_to_timestamp(Some(Utc::now())),
+        updated_by,
     };
-    super::ALARMS_DB_CLIENT.run_with_client(do_update).await
+    let returned_copy = timer.clone();
+    let do_update = |mut client: AlarmsDbConnectionAdapter| async move {
+        client.timers_conn.update(timer).await
+    };
+    super::ALARMS_DB_CLIENT
+        .run_with_client(do_update)
+        .await
+        .map(|_| returned_copy)
+}
+
+fn datetime_to_timestamp(datetime: Option<DateTime<Utc>>) -> Option<Timestamp> {
+    datetime.map(|dt| Timestamp {
+        seconds: dt.timestamp(),
+        nanos: dt.nanosecond() as i32,
+    })
+}
+
+fn string_to_timer_type(value: &str) -> TimerType {
+    TimerType::from_str_name(value).unwrap_or(TimerType::Unknown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datetime_to_timestamp_converts_properly() {
+        let ts = Timestamp {
+            seconds: 1_234_567_890,
+            nanos: 0,
+        };
+        let dt = DateTime::parse_from_rfc3339("2009-02-13T23:31:30.000Z")
+            .unwrap()
+            .to_utc();
+        let result = datetime_to_timestamp(Some(dt)).unwrap();
+        assert_eq!(result, ts);
+
+        assert!(datetime_to_timestamp(None).is_none());
+    }
+
+    #[test]
+    fn string_to_timer_type_converts_properly() {
+        assert_eq!(
+            TimerType::BypassReminder,
+            string_to_timer_type("TimerType_BYPASS_REMINDER")
+        );
+        assert_eq!(TimerType::Snooze, string_to_timer_type("TimerType_SNOOZE"));
+        assert_eq!(
+            TimerType::Unknown,
+            string_to_timer_type("Not an instance of TimerType")
+        );
+    }
 }

--- a/src/graphql/alarms/mod.rs
+++ b/src/graphql/alarms/mod.rs
@@ -3,10 +3,7 @@
 //! Provides the query implementations for the Alarms GraphQL interface.
 
 use crate::{
-    g_rpc::{
-        alarms_db, alarms_svc,
-        proto::{google::protobuf::Empty, services::alarms},
-    },
+    g_rpc::{alarms_db, alarms_svc},
     graphql::alarms::types::Alarm,
     pubsub::{Subscriber, kafka_impl::KafkaSubscriber},
 };
@@ -14,7 +11,7 @@ use async_graphql::{Error, Object, Subscription};
 use chrono::{DateTime, Utc};
 use rust_env_var_lib::env_var;
 use tokio_stream::{Stream, StreamExt};
-use tonic::{Code, Request, Status};
+use tonic::{Code, Status};
 use tracing::error;
 use types::{AlarmGroup, AlarmGroupMetadatum, AlarmTimer, UserLayout};
 use uuid::Uuid;
@@ -63,18 +60,12 @@ impl AlarmsMutations {
         &self, device: String, end_time: Option<DateTime<Utc>>,
         timer_type: String, updated_by: String,
     ) -> Result<AlarmTimer, Error> {
-        let timer_type_enum = utils::string_to_timer_type(&timer_type);
-        let end_time_ts = utils::datetime_to_timestamp(end_time);
-        let alarm_timer = alarms::AlarmTimer {
-            device,
-            end_time: end_time_ts,
-            timer_type: timer_type_enum as i32,
-            updated_at: None,
-            updated_by,
-        };
-        match alarms_db::timers::create(Request::new(alarm_timer.clone())).await
+        match alarms_db::timers::create(
+            device, end_time, timer_type, updated_by,
+        )
+        .await
         {
-            Ok(_) => Ok(AlarmTimer::from(alarm_timer)),
+            Ok(alarm_timer) => Ok(AlarmTimer::from(alarm_timer)),
             Err(e) => handle_error(e, "creating alarm timer"),
         }
     }
@@ -83,12 +74,7 @@ impl AlarmsMutations {
     async fn delete_alarm_timer(
         &self, device: String, timer_type: String,
     ) -> Result<String, Error> {
-        let timer_type_enum = utils::string_to_timer_type(&timer_type);
-        let request = alarms::DeleteRequest {
-            device: device.clone(),
-            timer_type: timer_type_enum as i32,
-        };
-        match alarms_db::timers::delete(Request::new(request)).await {
+        match alarms_db::timers::delete(device.clone(), timer_type).await {
             Ok(_) => Ok(device),
             Err(e) => handle_error(e, "deleting alarm timer"),
         }
@@ -105,24 +91,18 @@ impl AlarmsMutations {
         }
     }
 
-    /// A request to update an alarms timer.
+    /// A request to update an existing alarms timer of the specified
+    /// [`TimerType`](crate::g_rpc::proto::services::alarms::TimerType).
     async fn update_alarm_timer(
         &self, device: String, end_time: Option<DateTime<Utc>>,
         timer_type: String, updated_by: String,
     ) -> Result<AlarmTimer, Error> {
-        let timer_type_enum = utils::string_to_timer_type(&timer_type);
-        let end_time_ts = utils::datetime_to_timestamp(end_time);
-        let alarm_timer_proto = alarms::AlarmTimer {
-            device,
-            end_time: end_time_ts,
-            timer_type: timer_type_enum as i32,
-            updated_at: None,
-            updated_by,
-        };
-        match alarms_db::timers::update(Request::new(alarm_timer_proto.clone()))
-            .await
+        match alarms_db::timers::update(
+            device, end_time, timer_type, updated_by,
+        )
+        .await
         {
-            Ok(_) => Ok(AlarmTimer::from(alarm_timer_proto)),
+            Ok(alarm_timer) => Ok(AlarmTimer::from(alarm_timer)),
             Err(e) => handle_error(e, "updating alarm timer"),
         }
     }
@@ -137,7 +117,7 @@ impl AlarmsQueries {
     async fn alarms_group_metadata(
         &self,
     ) -> Result<Vec<AlarmGroupMetadatum>, Error> {
-        match alarms_db::groups::read_metadata(Request::new(Empty {})).await {
+        match alarms_db::groups::read_metadata().await {
             Ok(response) => {
                 let mapped_response = response
                     .metadata
@@ -154,11 +134,7 @@ impl AlarmsQueries {
     async fn alarms_groups(
         &self, groups: Vec<String>,
     ) -> Result<Vec<AlarmGroup>, Error> {
-        match alarms_db::groups::read_groups(Request::new(
-            alarms::GroupsRequest { groups },
-        ))
-        .await
-        {
+        match alarms_db::groups::read_groups(groups).await {
             Ok(response) => {
                 let mapped_response = response
                     .alarm_groups
@@ -173,7 +149,7 @@ impl AlarmsQueries {
 
     /// Reads all [`UserLayout`]s in the database.
     async fn alarms_user_layouts(&self) -> Result<Vec<UserLayout>, Error> {
-        match alarms_db::layouts::read_layouts(Request::new(Empty {})).await {
+        match alarms_db::layouts::read_layouts().await {
             Ok(response) => {
                 let mapped_response = response
                     .layouts
@@ -198,12 +174,7 @@ impl AlarmsQueries {
     async fn alarms_timers(
         &self, timer_type: String, user: String,
     ) -> Result<Vec<AlarmTimer>, Error> {
-        match alarms_db::timers::read(Request::new(alarms::ReadRequest {
-            timer_type: utils::string_to_timer_type(&timer_type) as i32,
-            user,
-        }))
-        .await
-        {
+        match alarms_db::timers::read(timer_type, user).await {
             Ok(response) => {
                 let timers = response
                     .alarm_timers

--- a/src/graphql/alarms/types/tests.rs
+++ b/src/graphql/alarms/types/tests.rs
@@ -11,7 +11,10 @@ fn alarm_from_proto_to_gql() {
         state: State::Ok as i32,
         severity: Severity::Unknown as i32,
         acknowledgeable: false,
-        time: utils::datetime_to_timestamp(Some(Utc::now())),
+        time: Some(Timestamp {
+            seconds: 1_234_567_890,
+            nanos: 0,
+        }),
         epics_type: String::new(),
         user: "test user".to_string(),
         wake: None,
@@ -24,10 +27,10 @@ fn alarm_from_proto_to_gql() {
     assert_eq!(status.state(), output.state);
     assert_eq!(status.severity(), output.severity);
     assert_eq!(status.acknowledgeable, output.acknowledgeable);
-    assert_eq!(status.time, utils::datetime_to_timestamp(output.time));
+    assert_eq!(utils::timestamp_to_datetime(status.time), output.time);
     assert_eq!(status.epics_type, output.epics_type);
     assert_eq!(status.user, output.user);
-    assert_eq!(status.wake, utils::datetime_to_timestamp(output.wake));
+    assert_eq!(utils::timestamp_to_datetime(status.wake), output.wake);
 }
 
 #[test]

--- a/src/graphql/alarms/utils.rs
+++ b/src/graphql/alarms/utils.rs
@@ -1,24 +1,16 @@
 //! GraphQL Alarms Utilities
 //!
-//! Provides various utility functions that are useful in the context of alarms.
+//! Conversion helpers between protobuf wire types and GraphQL domain types:
+//! - [`timer_type_to_string`] — converts a [`TimerType`] `i32` to its string name
+//! - [`timestamp_to_datetime`] — converts a protobuf [`Timestamp`] to [`DateTime<Utc>`]
 
 use crate::g_rpc::proto::google::protobuf::Timestamp;
 use crate::g_rpc::proto::services::alarms::TimerType;
-use chrono::{DateTime, Timelike, Utc};
+use chrono::{DateTime, Utc};
 
-pub fn datetime_to_timestamp(
-    datetime: Option<DateTime<Utc>>,
-) -> Option<Timestamp> {
-    datetime.map(|dt| Timestamp {
-        seconds: dt.timestamp(),
-        nanos: dt.nanosecond() as i32,
-    })
-}
-
-pub fn string_to_timer_type(value: &str) -> TimerType {
-    TimerType::from_str_name(value).unwrap_or(TimerType::Unknown)
-}
-
+/// Converts a protobuf [`TimerType`] integer representation to its string name.
+///
+/// Unrecognised values are treated as [`TimerType::Unknown`].
 pub fn timer_type_to_string(timer_type: i32) -> String {
     TimerType::try_from(timer_type)
         .unwrap_or(TimerType::Unknown)
@@ -26,6 +18,10 @@ pub fn timer_type_to_string(timer_type: i32) -> String {
         .to_string()
 }
 
+/// Converts a protobuf [`Timestamp`] to a [`DateTime<Utc>`].
+///
+/// Returns `None` if `timestamp` is `None` or if the seconds/nanos
+/// values cannot be represented as a valid [`DateTime`].
 pub fn timestamp_to_datetime(
     timestamp: Option<Timestamp>,
 ) -> Option<DateTime<Utc>> {
@@ -38,34 +34,6 @@ pub fn timestamp_to_datetime(
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn datetime_to_timestamp_converts_properly() {
-        let ts = Timestamp {
-            seconds: 1_234_567_890,
-            nanos: 0,
-        };
-        let dt = DateTime::parse_from_rfc3339("2009-02-13T23:31:30.000Z")
-            .unwrap()
-            .to_utc();
-        let result = datetime_to_timestamp(Some(dt)).unwrap();
-        assert_eq!(result, ts);
-
-        assert!(datetime_to_timestamp(None).is_none());
-    }
-
-    #[test]
-    fn string_to_timer_type_converts_properly() {
-        assert_eq!(
-            TimerType::BypassReminder,
-            string_to_timer_type("TimerType_BYPASS_REMINDER")
-        );
-        assert_eq!(TimerType::Snooze, string_to_timer_type("TimerType_SNOOZE"));
-        assert_eq!(
-            TimerType::Unknown,
-            string_to_timer_type("Not an instance of TimerType")
-        );
-    }
 
     #[test]
     fn timer_type_to_string_converts_properly() {


### PR DESCRIPTION
The AI got a little punchy in this PR description, but it's angry about code I wrote so I left it in. 😆 

---

## Make the code say what it means

The GraphQL layer was changing for two reasons — when the GraphQL schema changed, and when the protobuf schema changed. That's one reason too many.

This PR fixes that.

---

### What was wrong

Look at what the GraphQL resolver was doing before:

```rust
let timer_type_enum = utils::string_to_timer_type(&timer_type);
let alarm_timer = alarms::AlarmTimer {
    device,
    end_time: utils::datetime_to_timestamp(end_time),
    timer_type: timer_type_enum as i32,
    updated_at: None,
    updated_by,
};
alarms_db::timers::create(Request::new(alarm_timer.clone())).await
```

A GraphQL resolver building a protobuf struct. Wrapping it in a `tonic::Request`. Knowing about `i32` enum representations. That's not a resolver — that's a protocol adapter wearing a resolver's clothes.

The resolver's job is to take what the user asked for and hand it to the right module. That's it.

---

### What we did

We moved the protocol knowledge to where it belongs: [`src/g_rpc/alarms_db/timers/mod.rs`](src/g_rpc/alarms_db/timers/mod.rs). The `create`, `update`, `delete`, and `read` functions now speak the language of the caller — plain strings, plain datetimes — and translate to proto internally.

The resolver now reads like this:

```rust
alarms_db::timers::create(device, end_time, timer_type, updated_by).await
```

That's what it should have always looked like.

The same principle applied to [`src/g_rpc/alarms_db/layouts/mod.rs`](src/g_rpc/alarms_db/layouts/mod.rs): `read_layouts` was taking a `Request<Empty>` — a request with nothing in it. We deleted the parameter. If there's no information, don't pass it.

---

### Where the helpers went

`datetime_to_timestamp` and `string_to_timer_type` were living in [`src/graphql/alarms/utils.rs`](src/graphql/alarms/utils.rs). They're gone from there now. They live in [`src/g_rpc/alarms_db/timers/mod.rs`](src/g_rpc/alarms_db/timers/mod.rs) as private functions, because that's the only place that needs them. Private by default. Expose only what you must.

The tests moved with the code. Tests belong next to the thing they test.

---

### The result

The GraphQL layer imports fewer things. The `g_rpc` layer owns its own translation. Each module has one reason to change.

That's the goal. Make it work, make it right, make it simple. This PR is the "make it right" step.