### PR TITLE
Upgrade networking crates to use aws-lc for TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,12 +360,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http",
  "http-body",
@@ -350,7 +374,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -400,6 +423,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -496,6 +521,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +553,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -555,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -709,6 +754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,7 +810,6 @@ dependencies = [
  "reqwest",
  "rust-env-var-lib",
  "rust-pubsub-lib",
- "rustls",
  "serde",
  "serde_json",
  "tokio",
@@ -769,7 +819,7 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -842,6 +892,12 @@ dependencies = [
  "autocfg",
  "tokio",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1132,7 +1188,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1344,6 +1399,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1653,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -1882,6 +2002,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -2053,9 +2174,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2074,22 +2195,21 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2135,6 +2255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,9 +2282,9 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2163,12 +2292,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-native-certs"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
+ "openssl-probe",
  "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2182,11 +2314,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2205,6 +2365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "sasl2-sys"
 version = "0.1.22+2.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2384,44 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2356,6 +2563,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2727,21 +2950,37 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "async-compression",
  "bitflags",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
- "http-body-util",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2924,6 +3163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3036,12 +3285,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ async-graphql = { version = "7", features = ["chrono"] }
 async-graphql-axum = "7"
 async-stream = "0.3"
 axum = { version = "0.8", features = ["ws"] }
-axum-server = { version = "0.7", features = ["tls-rustls-no-provider"] }
+axum-server = { version = "0.8", features = ["tls-rustls"] }
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
@@ -20,8 +20,7 @@ futures = "0.3"
 futures-util = "0.3"
 http = "1"
 prost = "0.14"
-reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls", "rustls-tls-webpki-roots", "json"] }
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
+reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls", "json"] }
 rust-env-var-lib = { git = "https://github.com/fermi-ad/rust-env-var-lib", tag = "v1.2.0" }
 rust-pubsub-lib = { git = "https://github.com/fermi-ad/rust-pubsub-lib", tag = "v9.0.0", features = ["kafka"] }
 serde = { version = "1", features = ["derive"] }
@@ -29,9 +28,9 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
-tonic = { version = "0.14", features = ["tls-ring"] }
+tonic = { version = "0.14", features = ["tls-aws-lc"] }
 tonic-prost = "0.14"
-tower-http = { version = "0.6", features = ["cors", "compression-deflate", "decompression-deflate"] }
+tower-http = { version = "0.7", features = ["cors", "compression-deflate", "decompression-deflate"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ FROM gcr.io/distroless/cc-debian13
 COPY --from=builder /app/target/release/extapi-acsys /usr/local/bin/extapi-acsys
 COPY --from=builder /lib/x86_64-linux-gnu/libsasl2.so.2 /lib/x86_64-linux-gnu/libsasl2.so.2
 
-EXPOSE 8000
+EXPOSE 443
 CMD ["extapi-acsys"]

--- a/src/g_rpc/alarms_db/mod.rs
+++ b/src/g_rpc/alarms_db/mod.rs
@@ -16,10 +16,7 @@ use crate::g_rpc::{
 };
 use std::sync::LazyLock;
 use tokio::try_join;
-use tonic::{
-    async_trait,
-    transport::{Channel, Error},
-};
+use tonic::transport::{Channel, Error};
 
 /// The environment variable name to use when requesting the location of the alarms DB service.
 const GRPC_ALARMS_DB_HOST: &str = "GRPC_ALARMS_DB_HOST";
@@ -36,7 +33,6 @@ struct AlarmsDbConnectionAdapter {
     pub layouts_conn: UserLayoutsServiceClient<Channel>,
     pub timers_conn: AlarmTimerServiceClient<Channel>,
 }
-#[async_trait]
 impl ConnectionAdapter for AlarmsDbConnectionAdapter {
     async fn new(host: String) -> Result<Self, Error> {
         let (groups_conn, layouts_conn, timers_conn) = try_join!(

--- a/src/g_rpc/alarms_svc/mod.rs
+++ b/src/g_rpc/alarms_svc/mod.rs
@@ -17,7 +17,7 @@ use crate::g_rpc::{
 use chrono::{DateTime, Timelike, Utc};
 use std::sync::LazyLock;
 use tonic::{
-    Response, Status, async_trait,
+    Response, Status,
     transport::{Channel, Error},
 };
 
@@ -109,7 +109,6 @@ async fn do_snapshot_request(
 struct AlarmsServiceConnectionAdapter {
     pub conn: AlarmCommandsClient<Channel>,
 }
-#[async_trait]
 impl ConnectionAdapter for AlarmsServiceConnectionAdapter {
     async fn new(host: String) -> Result<Self, Error> {
         let conn = AlarmCommandsClient::connect(host).await?;

--- a/src/g_rpc/connection_utils/mod.rs
+++ b/src/g_rpc/connection_utils/mod.rs
@@ -5,20 +5,19 @@
 
 use rust_env_var_lib::env_var;
 use tokio::sync::RwLock;
-use tonic::{Response, Status, async_trait, transport::Error};
+use tonic::{Response, Status, transport::Error};
 use tracing::error;
 use uuid::Uuid;
 
 /// The trait to be implemented by wrapped objects within [`ConnectionPort`]. The idea is this will house an inner gRPC client
 /// backed by [`tonic::transport::Channel`]. `Channel` offers a lightweight implementation of [`Clone`] that multiplexes an HTTPS connection
 /// to the host server. This allows multiple threads to share the connection simultaneously.
-#[async_trait]
 pub trait ConnectionAdapter: Clone + Sized {
     /// Creates an instance of the adapter.
     ///
     /// This function is `async` to allow the connection to be made as part of the initialization process.
     /// The return value is a [`Result`] to allow an [`Error`] to propagate to the calling code.
-    async fn new(host: String) -> Result<Self, Error>;
+    fn new(host: String) -> impl Future<Output = Result<Self, Error>>;
 }
 
 /// A structure to hold a lock on the inner [`ConnectionAdapter`] and safely run several requests to the same remote host at once.

--- a/src/g_rpc/connection_utils/mod.rs
+++ b/src/g_rpc/connection_utils/mod.rs
@@ -17,7 +17,7 @@ pub trait ConnectionAdapter: Clone + Sized {
     ///
     /// This function is `async` to allow the connection to be made as part of the initialization process.
     /// The return value is a [`Result`] to allow an [`Error`] to propagate to the calling code.
-    fn new(host: String) -> impl Future<Output = Result<Self, Error>>;
+    async fn new(host: String) -> Result<Self, Error>;
 }
 
 /// A structure to hold a lock on the inner [`ConnectionAdapter`] and safely run several requests to the same remote host at once.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use tracing::{error, info, subscriber};
+use tracing::{info, subscriber};
 use tracing_subscriber::{
     Registry, filter::EnvFilter, fmt::layer, layer::SubscriberExt,
 };
@@ -32,14 +32,6 @@ async fn main() {
     subscriber::set_global_default(subscriber)
         .expect("Unable to set global default subscriber");
 
-    match rustls::crypto::ring::default_provider().install_default() {
-        Ok(_) => {
-            info!("starting");
-            graphql::start_service(args.port).await;
-        }
-        Err(e) => {
-            error!("failed to install default crypto provider: {:?}", e);
-            return;
-        }
-    }
+    info!("starting");
+    graphql::start_service(args.port).await;
 }


### PR DESCRIPTION
## Modernize TLS stack: migrate from `ring` to `aws-lc-rs`, upgrade dependencies

### Make It Simple

This PR is about removing things. Every line deleted is a line that cannot be wrong.

The most visible deletion is in [`src/main.rs`](src/main.rs:19): eight lines of startup ceremony that existed solely to satisfy `ring`'s requirement to be manually installed as the global crypto provider:

```rust
// Deleted — this was never about what the program does
match rustls::crypto::ring::default_provider().install_default() {
    Ok(_) => {
        info!("starting");
        graphql::start_service(args.port).await;
    }
    Err(e) => {
        error!("failed to install default crypto provider: {:?}", e);
        return;
    }
}
```

`aws-lc-rs` installs itself. The program now says what it means:

```rust
info!("starting");
graphql::start_service(args.port).await;
```

### Make the System Tell the Truth

[`Dockerfile`](Dockerfile:18) declared `EXPOSE 8000`. [`src/main.rs`](src/main.rs:14) defaulted to port `443`. One of them was lying. Now they agree.

### Remove Waste

The [`ConnectionAdapter`](src/g_rpc/connection_utils/mod.rs:15) trait and its implementors in [`alarms_db`](src/g_rpc/alarms_db/mod.rs:33) and [`alarms_svc`](src/g_rpc/alarms_svc/mod.rs:109) carried `#[async_trait]` — a proc-macro workaround for the absence of native `async fn` in traits before Rust 1.75. That workaround boxes the returned future on every call (a heap allocation) and makes type signatures harder to read. Rust now supports this natively. The macro is gone.

---

### Why `aws-lc-rs` — an in-depth discussion

The move away from OpenSSL to `rustls` was the right call. CVEs in `openssl-sys` are real, the C FFI boundary is a genuine risk surface, and a pure-Rust TLS stack is a meaningful improvement. That reasoning is sound.

The question is which cryptographic backend sits under `rustls`. There are two serious options: `ring` and `aws-lc-rs`. Here is why `aws-lc-rs` is the better choice going forward — not instead of the `rustls` migration, but as the completion of it.

**`ring` is not actively maintained.** The last `ring` release was 0.17 in late 2023. Issues and PRs accumulate with slow response. The `rustls` project itself [switched its default backend to `aws-lc-rs` in `rustls 0.23`](https://github.com/rustls/rustls/releases/tag/v/0.23.0) precisely because of this. Staying on `ring` means depending on a library the ecosystem is actively moving away from — which is the same problem that motivated leaving OpenSSL.

**`aws-lc-rs` is a fork of BoringSSL**, Google's hardened, stripped-down fork of OpenSSL. BoringSSL removes the long tail of legacy algorithms and APIs that are the source of most OpenSSL CVEs. AWS-LC tracks BoringSSL closely and is maintained by a dedicated AWS security team. The CVE risk profile is fundamentally different from `openssl-sys`.

**`aws-lc-rs` is FIPS 140-3 validated.** `ring` is not and has no plans to be. If any work here ever touches a US federal environment or a regulated industry context, `ring` is a dead end. `aws-lc-rs` is not.

**The ecosystem has already decided.** `rustls 0.23+`, `tonic 0.14`, `axum-server 0.8`, and `reqwest 0.13` all default to or prefer `aws-lc-rs`. Using `ring` now requires opting back in against the grain of every upstream library. That friction will only increase.

The concern about CVEs that drove the OpenSSL → `rustls` migration is exactly the concern that points toward `aws-lc-rs` over `ring`. The logic is consistent; only the conclusion changes.

| | `openssl-sys` | `ring` | `aws-lc-rs` |
|---|---|---|---|
| **Language** | C (FFI) | Rust + C | Rust + C (BoringSSL) |
| **CVE history** | High | Low (small surface) | Low (reduced BoringSSL surface) |
| **Active maintenance** | Yes | Slow | Yes (AWS team) |
| **FIPS 140-3** | Via OpenSSL FIPS module | No | Yes |
| **`rustls` default** | No | Was (pre-0.23) | Yes (0.23+) |
| **Manual provider install** | N/A | Required | Not required |

### Changes

| File | Change |
|---|---|
| [`Cargo.toml`](Cargo.toml) | Upgrade `axum-server` `0.7→0.8`, `reqwest` `0.12→0.13`, `tower-http` `0.6→0.7`; switch `tonic` to `tls-aws-lc`; remove direct `rustls` dep |
| [`src/main.rs`](src/main.rs) | Delete `ring` bootstrap block; remove unused `error` import |
| [`src/g_rpc/connection_utils/mod.rs`](src/g_rpc/connection_utils/mod.rs) | Remove `#[async_trait]` from `ConnectionAdapter` trait |
| [`src/g_rpc/alarms_db/mod.rs`](src/g_rpc/alarms_db/mod.rs) | Remove `#[async_trait]` from `AlarmsDbConnectionAdapter` impl |
| [`src/g_rpc/alarms_svc/mod.rs`](src/g_rpc/alarms_svc/mod.rs) | Remove `#[async_trait]` from `AlarmsServiceConnectionAdapter` impl |
| [`Dockerfile`](Dockerfile) | `EXPOSE 8000` → `EXPOSE 443` |