### PR TITLE
Bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "extapi-acsys"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.4.2"
+version = "6.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26569a2763497b7bd3fbd19374b774ea6038c5293678771259cd534d49740ff"
+checksum = "4633d16a2350341713c379d6d06a4b9e1845329386026a49ce4fd09c2f3b16f6"
 dependencies = [
  "derive_builder",
  "log",
@@ -1108,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1543,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2022,9 +2022,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2444,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2629,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2648,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2984,7 +2984,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1",
  "thiserror",
 ]
@@ -3045,9 +3045,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3355,9 +3355,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -3479,6 +3479,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "extapi-acsys"
 version = "0.6.2"
 edition = "2024"
 
+[features]
+default = ["kafka"]
+kafka = ["rust-pubsub-lib/kafka"]
+
 [build-dependencies]
 tonic-prost-build = "0.14"
 protoc-bin-vendored = "3"
@@ -22,7 +26,7 @@ http = "1"
 prost = "0.14"
 reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls", "json"] }
 rust-env-var-lib = { git = "https://github.com/fermi-ad/rust-env-var-lib", tag = "v1.2.0" }
-rust-pubsub-lib = { git = "https://github.com/fermi-ad/rust-pubsub-lib", tag = "v10.0.0", features = ["kafka"] }
+rust-pubsub-lib = { git = "https://github.com/fermi-ad/rust-pubsub-lib", tag = "v10.0.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -36,7 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-rust-pubsub-lib = { git = "https://github.com/fermi-ad/rust-pubsub-lib", tag = "v10.0.0", features = ["kafka", "testing-utils"] }
+rust-pubsub-lib = { git = "https://github.com/fermi-ad/rust-pubsub-lib", tag = "v10.0.0", features = ["testing-utils"] }
 tower = "0.5"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extapi-acsys"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 
 [features]

--- a/src/g_rpc/dpm/mod.rs
+++ b/src/g_rpc/dpm/mod.rs
@@ -89,8 +89,6 @@ pub async fn set_device(
 ) -> _TonicQueryResult<Vec<i32>> {
     use tonic::{IntoRequest, metadata::MetadataValue};
 
-    info!("setting to {:?}", &value);
-
     // Build the setting request. This function only sets one device, so the
     // request only has a 1-element array containing the setting.
 
@@ -116,6 +114,8 @@ pub async fn set_device(
                 ));
             }
         }
+    } else {
+	warn!("request lacks credentials ... setting has been blocked");
     }
 
     let SettingReply { status } = conn.0.clone().set(req).await?.into_inner();

--- a/src/g_rpc/dpm/mod.rs
+++ b/src/g_rpc/dpm/mod.rs
@@ -108,21 +108,20 @@ pub async fn _set_device(
         match MetadataValue::try_from(format!("Bearer {token}")) {
             Ok(val) => {
                 req.metadata_mut().insert("authorization", val);
-
-                let SettingReply { status } =
-                    conn.0.clone().set(req).await?.into_inner();
-
-                Ok(status
-                    .iter()
-                    .map(|v| v.facility_code + v.status_code * 256)
-                    .collect())
             }
             Err(err) => {
                 error!("unable to pass credentials : {}", &err);
-                Err(tonic::Status::internal("couldn't add credentials"))
+                return Err(tonic::Status::internal(
+                    "couldn't add credentials",
+                ));
             }
         }
-    } else {
-        Ok(vec![7 + -59 * 256])
     }
+
+    let SettingReply { status } = conn.0.clone().set(req).await?.into_inner();
+
+    Ok(status
+        .iter()
+        .map(|v| v.facility_code + v.status_code * 256)
+        .collect())
 }

--- a/src/g_rpc/dpm/mod.rs
+++ b/src/g_rpc/dpm/mod.rs
@@ -115,7 +115,7 @@ pub async fn set_device(
             }
         }
     } else {
-	warn!("request lacks credentials ... setting has been blocked");
+        warn!("request lacks credentials ... setting has been blocked");
     }
 
     let SettingReply { status } = conn.0.clone().set(req).await?.into_inner();

--- a/src/g_rpc/dpm/mod.rs
+++ b/src/g_rpc/dpm/mod.rs
@@ -83,7 +83,7 @@ pub async fn acquire_devices(
 // This function wraps the logic needed to make the `ApplySettings()`
 // gRPC transaction.
 
-pub async fn _set_device(
+pub async fn set_device(
     conn: &Connection, session_id: Option<String>, device: String,
     value: device::Value,
 ) -> _TonicQueryResult<Vec<i32>> {

--- a/src/graphql/acsys/datastream/archivestream.rs
+++ b/src/graphql/acsys/datastream/archivestream.rs
@@ -10,6 +10,11 @@ use std::{pin::Pin, task::Poll};
 // specify more than one device. In our case, we only ask for one device
 // per stream. This wrapper Stream, once it sees and returns the empty
 // array, will close the stream.
+//
+// A device that is in a PEND (or other error) state will send a status
+// reply instead of the normal empty-array sentinel. We treat a status
+// reply as a terminal condition as well, so that the live-data channel
+// is not left waiting for a sentinel that will never arrive.
 
 pub struct ArchiveStream<S>
 where
@@ -51,14 +56,111 @@ where
         let Some(ref mut inner) = self.inner else {
             return Poll::Ready(None);
         };
-
         let reply = inner.poll_next_unpin(ctxt);
 
-        if let Poll::Ready(Some(ref packet)) = reply
-            && packet.data.is_empty()
-        {
-            self.inner = None;
+        if let Poll::Ready(Some(ref packet)) = reply {
+            let is_terminal = packet.data.is_empty()
+                || matches!(
+                    packet.data.as_slice(),
+                    [global::DataInfo {
+                        result: global::DataType::StatusReply(_),
+                        ..
+                    }]
+                );
+
+            if is_terminal {
+                self.inner = None;
+            }
         }
         reply
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::global;
+    use futures::stream::{self, StreamExt};
+
+    fn data_info(ts: f64) -> global::DataInfo {
+        global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::Scalar(global::Scalar {
+                scalar_value: ts / 2.0,
+            }),
+        }
+    }
+
+    fn status_info(ts: f64) -> global::DataInfo {
+        global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::StatusReply(global::StatusReply {
+                status: -1,
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_empty_sentinel_closes_stream() {
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(100.0), data_info(110.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![],
+            }, // sentinel
+            // This packet must never be delivered.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(120.0)],
+            },
+        ];
+
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(100.0), data_info(110.0)]);
+
+        // The empty sentinel is forwarded, then the stream closes.
+        let r = s.next().await.unwrap();
+        assert!(r.data.is_empty());
+
+        assert!(s.next().await.is_none());
+    }
+
+    // Regression test: DPM sends a status reply (PEND) instead of the
+    // normal empty-array sentinel when a device is unavailable. The
+    // ArchiveStream must treat this as a terminal condition so that
+    // DataChannel is not left in Buffering mode forever, silently
+    // swallowing all subsequent live data.
+    #[tokio::test]
+    async fn test_status_reply_closes_stream() {
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(100.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![status_info(200.0)], // PEND instead of sentinel
+            },
+            // This packet must never be delivered.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(300.0)],
+            },
+        ];
+
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(100.0)]);
+
+        // The status reply is forwarded, then the stream closes.
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![status_info(200.0)]);
+
+        assert!(s.next().await.is_none());
     }
 }

--- a/src/graphql/acsys/datastream/archivestream.rs
+++ b/src/graphql/acsys/datastream/archivestream.rs
@@ -90,14 +90,37 @@ mod test {
         }
     }
 
-    fn status_info(ts: f64) -> global::DataInfo {
+    fn waveform_info(ts: f64) -> global::DataInfo {
         global::DataInfo {
             timestamp: ts,
-            result: global::DataType::StatusReply(global::StatusReply {
-                status: -1,
+            result: global::DataType::ScalarArray(global::ScalarArray {
+                scalar_array_value: vec![ts, ts + 1.0, ts + 2.0],
             }),
         }
     }
+
+    fn status_info_code(ts: f64, code: i16) -> global::DataInfo {
+        global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::StatusReply(global::StatusReply {
+                status: code,
+            }),
+        }
+    }
+
+    fn status_info(ts: f64) -> global::DataInfo {
+        status_info_code(ts, -1)
+    }
+
+    fn sentinel(ref_id: i32) -> global::DataReply {
+        global::DataReply {
+            ref_id,
+            data: vec![],
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Terminal-condition tests
 
     #[tokio::test]
     async fn test_empty_sentinel_closes_stream() {
@@ -161,6 +184,263 @@ mod test {
         let r = s.next().await.unwrap();
         assert_eq!(r.data, vec![status_info(200.0)]);
 
+        assert!(s.next().await.is_none());
+    }
+
+    // The empty sentinel as the very first packet: no data precedes it.
+    // The sentinel is still forwarded and the stream closes immediately.
+    #[tokio::test]
+    async fn test_sentinel_as_first_packet() {
+        let input = [
+            sentinel(0),
+            // Must never be delivered.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(1.0)],
+            },
+        ];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert!(r.data.is_empty());
+
+        assert!(s.next().await.is_none());
+    }
+
+    // A status reply as the very first packet (device immediately in PEND).
+    #[tokio::test]
+    async fn test_status_reply_as_first_packet() {
+        let input = [
+            global::DataReply {
+                ref_id: 5,
+                data: vec![status_info(0.0)],
+            },
+            // Must never be delivered.
+            global::DataReply {
+                ref_id: 5,
+                data: vec![data_info(1.0)],
+            },
+        ];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![status_info(0.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // A status reply with a specific non-(-1) ACNET code is still treated
+    // as a terminal condition.
+    #[tokio::test]
+    async fn test_status_reply_with_specific_code_closes_stream() {
+        // ACNET status: facility 17, error 42 → (42 * 256 + 17) as i16
+        let code = (42i16 * 256) + 17;
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(1.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![status_info_code(2.0, code)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(3.0)],
+            },
+        ];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(1.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![status_info_code(2.0, code)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // A packet whose `data` vec contains a status reply alongside other
+    // elements is NOT a terminal condition — the `matches!` guard only fires
+    // on a single-element slice.
+    #[tokio::test]
+    async fn test_multi_element_packet_with_status_is_not_terminal() {
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                // Two elements: a status and a scalar — not a sentinel.
+                data: vec![status_info(1.0), data_info(2.0)],
+            },
+            sentinel(0),
+        ];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        // The mixed packet must be forwarded as-is.
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![status_info(1.0), data_info(2.0)]);
+
+        // The sentinel closes the stream.
+        let r = s.next().await.unwrap();
+        assert!(r.data.is_empty());
+
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Normal pass-through tests
+
+    // An empty source stream produces no items.
+    #[tokio::test]
+    async fn test_empty_source_stream() {
+        let input: Vec<global::DataReply> = vec![];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        assert!(s.next().await.is_none());
+    }
+
+    // When the underlying source closes naturally (no sentinel), the
+    // ArchiveStream closes too without panicking.
+    #[tokio::test]
+    async fn test_source_closes_naturally_without_sentinel() {
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(1.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(2.0)],
+            },
+        ];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(1.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(2.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // Multiple data packets before the sentinel are all forwarded.
+    #[tokio::test]
+    async fn test_multiple_data_packets_then_sentinel() {
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(1.0), data_info(2.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(3.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(4.0), data_info(5.0), data_info(6.0)],
+            },
+            sentinel(0),
+            // Must never be delivered.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(99.0)],
+            },
+        ];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(1.0), data_info(2.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(3.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(
+            r.data,
+            vec![data_info(4.0), data_info(5.0), data_info(6.0)]
+        );
+
+        let r = s.next().await.unwrap();
+        assert!(r.data.is_empty());
+
+        assert!(s.next().await.is_none());
+    }
+
+    // Waveform (ScalarArray) data passes through without being treated as
+    // a terminal condition.
+    #[tokio::test]
+    async fn test_waveform_data_passes_through() {
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![waveform_info(10.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![waveform_info(20.0)],
+            },
+            sentinel(0),
+        ];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![waveform_info(10.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![waveform_info(20.0)]);
+
+        let r = s.next().await.unwrap();
+        assert!(r.data.is_empty());
+
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // ref_id and structural tests
+
+    // The ref_id on every forwarded packet must be preserved exactly.
+    #[tokio::test]
+    async fn test_ref_id_is_preserved() {
+        let input = [
+            global::DataReply {
+                ref_id: 7,
+                data: vec![data_info(1.0)],
+            },
+            global::DataReply {
+                ref_id: 7,
+                data: vec![data_info(2.0)],
+            },
+            sentinel(7),
+        ];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 7);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 7);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 7);
+        assert!(r.data.is_empty());
+
+        assert!(s.next().await.is_none());
+    }
+
+    // Polling the stream after it has been closed (inner = None) must
+    // continue to return None without panicking.
+    #[tokio::test]
+    async fn test_polling_after_close_returns_none() {
+        let input = [sentinel(0)];
+        let mut s = super::as_archive_stream(stream::iter(input));
+
+        // Consume the sentinel.
+        let r = s.next().await.unwrap();
+        assert!(r.data.is_empty());
+
+        // Every subsequent poll must return None.
+        assert!(s.next().await.is_none());
+        assert!(s.next().await.is_none());
         assert!(s.next().await.is_none());
     }
 }

--- a/src/graphql/acsys/datastream/datachannel.rs
+++ b/src/graphql/acsys/datastream/datachannel.rs
@@ -149,6 +149,9 @@ mod test {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Original integration test (kept intact)
+
     #[test]
     fn test_data_channel() {
         let mut chan = DataChannel::new();
@@ -213,5 +216,251 @@ mod test {
             }
             _ => panic!("unexpected result"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // DataChannel::new / initial state
+
+    #[test]
+    fn test_new_channel_is_buffering() {
+        let chan = DataChannel::new();
+        assert!(matches!(chan, DataChannel::Buffering { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // get_buffer tests
+
+    // A fresh channel has an empty buffer → get_buffer returns None.
+    #[test]
+    fn test_get_buffer_on_empty_buffering_channel_returns_none() {
+        let mut chan = DataChannel::new();
+        assert_eq!(chan.get_buffer(), None);
+        // Channel must still be in Buffering state.
+        assert!(matches!(chan, DataChannel::Buffering { .. }));
+    }
+
+    // After buffering live data, get_buffer returns it and clears the buffer.
+    #[test]
+    fn test_get_buffer_returns_buffered_data_and_clears() {
+        let mut chan = DataChannel::new();
+        chan.process_live_data(vec![data_info(1.0), data_info(2.0)], false);
+
+        let buf = chan.get_buffer();
+        assert_eq!(buf, Some(vec![data_info(1.0), data_info(2.0)]));
+
+        // Buffer must now be empty.
+        assert_eq!(chan.get_buffer(), None);
+    }
+
+    // get_buffer on a FeedThrough channel always returns None.
+    #[test]
+    fn test_get_buffer_on_feedthrough_returns_none() {
+        let mut chan = DataChannel::new();
+        // Transition to FeedThrough via the empty-archive sentinel.
+        chan.process_archive_data(vec![]);
+        assert!(matches!(chan, DataChannel::FeedThrough));
+        assert_eq!(chan.get_buffer(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // process_archive_data tests
+
+    // Non-empty archive data in Buffering mode is returned as-is.
+    #[test]
+    fn test_process_archive_data_nonempty_in_buffering_returns_data() {
+        let mut chan = DataChannel::new();
+        let result =
+            chan.process_archive_data(vec![data_info(10.0), data_info(20.0)]);
+        assert_eq!(result, Some(vec![data_info(10.0), data_info(20.0)]));
+        // Still in Buffering mode.
+        assert!(matches!(chan, DataChannel::Buffering { .. }));
+    }
+
+    // Empty archive sentinel with no buffered live data → None, switches to
+    // FeedThrough.
+    #[test]
+    fn test_process_archive_sentinel_with_empty_buffer_returns_none() {
+        let mut chan = DataChannel::new();
+        let result = chan.process_archive_data(vec![]);
+        assert_eq!(result, None);
+        assert!(matches!(chan, DataChannel::FeedThrough));
+    }
+
+    // Empty archive sentinel with buffered live data → returns the buffer,
+    // switches to FeedThrough.
+    #[test]
+    fn test_process_archive_sentinel_with_buffered_data_returns_buffer() {
+        let mut chan = DataChannel::new();
+        chan.process_live_data(vec![data_info(50.0), data_info(60.0)], false);
+
+        let result = chan.process_archive_data(vec![]);
+        assert_eq!(result, Some(vec![data_info(50.0), data_info(60.0)]));
+        assert!(matches!(chan, DataChannel::FeedThrough));
+    }
+
+    // Non-empty archive data in FeedThrough mode is returned (with a warning).
+    #[test]
+    fn test_process_archive_data_nonempty_in_feedthrough_returns_data() {
+        let mut chan = DataChannel::new();
+        chan.process_archive_data(vec![]); // → FeedThrough
+        let result = chan.process_archive_data(vec![data_info(99.0)]);
+        assert_eq!(result, Some(vec![data_info(99.0)]));
+    }
+
+    // Empty archive data in FeedThrough mode returns None (with a warning).
+    #[test]
+    fn test_process_archive_sentinel_in_feedthrough_returns_none() {
+        let mut chan = DataChannel::new();
+        chan.process_archive_data(vec![]); // → FeedThrough
+        let result = chan.process_archive_data(vec![]);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // process_live_data tests
+
+    // Empty live data in Buffering mode returns Data(None) without changing
+    // state (the guard branch).
+    #[test]
+    fn test_process_live_data_empty_in_buffering_returns_none() {
+        let mut chan = DataChannel::new();
+        assert_eq!(
+            chan.process_live_data(vec![], false),
+            BufferResult::Data(None)
+        );
+        // Buffer must still be empty.
+        assert_eq!(chan.get_buffer(), None);
+    }
+
+    // Empty live data in FeedThrough mode also returns Data(None).
+    #[test]
+    fn test_process_live_data_empty_in_feedthrough_returns_none() {
+        let mut chan = DataChannel::new();
+        chan.process_archive_data(vec![]); // → FeedThrough
+        assert_eq!(
+            chan.process_live_data(vec![], false),
+            BufferResult::Data(None)
+        );
+    }
+
+    // Live data in Buffering mode with archive_done=false is buffered.
+    #[test]
+    fn test_process_live_data_buffering_archive_not_done_buffers_data() {
+        let mut chan = DataChannel::new();
+        let result =
+            chan.process_live_data(vec![data_info(1.0), data_info(2.0)], false);
+        assert_eq!(result, BufferResult::Data(None));
+        // Data must be in the buffer.
+        assert_eq!(
+            chan.get_buffer(),
+            Some(vec![data_info(1.0), data_info(2.0)])
+        );
+    }
+
+    // Multiple live packets accumulate in the buffer.
+    #[test]
+    fn test_process_live_data_multiple_packets_accumulate() {
+        let mut chan = DataChannel::new();
+        chan.process_live_data(vec![data_info(1.0)], false);
+        chan.process_live_data(vec![data_info(2.0)], false);
+        chan.process_live_data(vec![data_info(3.0)], false);
+
+        assert_eq!(
+            chan.get_buffer(),
+            Some(vec![data_info(1.0), data_info(2.0), data_info(3.0)])
+        );
+    }
+
+    // Live data in Buffering mode with archive_done=true and an empty buffer
+    // → returns the live data directly (no prepend), transitions to FeedThrough.
+    #[test]
+    fn test_process_live_data_archive_done_empty_buffer_returns_live() {
+        let mut chan = DataChannel::new();
+        let result = chan
+            .process_live_data(vec![data_info(10.0), data_info(20.0)], true);
+        assert_eq!(
+            result,
+            BufferResult::Data(Some(vec![data_info(10.0), data_info(20.0)]))
+        );
+        assert!(matches!(chan, DataChannel::FeedThrough));
+    }
+
+    // Live data in Buffering mode with archive_done=true and a non-empty buffer
+    // → prepends the buffer to the live data, transitions to FeedThrough.
+    #[test]
+    fn test_process_live_data_archive_done_nonempty_buffer_prepends() {
+        let mut chan = DataChannel::new();
+        // Buffer two items first.
+        chan.process_live_data(vec![data_info(1.0), data_info(2.0)], false);
+
+        // Now archive is done; live data arrives.
+        let result =
+            chan.process_live_data(vec![data_info(3.0), data_info(4.0)], true);
+        assert_eq!(
+            result,
+            BufferResult::Data(Some(vec![
+                data_info(1.0),
+                data_info(2.0),
+                data_info(3.0),
+                data_info(4.0),
+            ]))
+        );
+        assert!(matches!(chan, DataChannel::FeedThrough));
+    }
+
+    // Live data in FeedThrough mode is passed through regardless of
+    // archive_done.
+    #[test]
+    fn test_process_live_data_feedthrough_passes_through() {
+        let mut chan = DataChannel::new();
+        chan.process_archive_data(vec![]); // → FeedThrough
+
+        let result =
+            chan.process_live_data(vec![data_info(5.0), data_info(6.0)], false);
+        assert_eq!(
+            result,
+            BufferResult::Data(Some(vec![data_info(5.0), data_info(6.0)]))
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Buffer overflow tests
+
+    // Exactly 1000 items in the buffer is still accepted (boundary).
+    #[test]
+    fn test_process_live_data_buffer_at_capacity_is_accepted() {
+        let mut chan = DataChannel::new();
+        // Fill the buffer to exactly 1000 items across two packets.
+        let first: Vec<_> = (0..500).map(|i| data_info(i as f64)).collect();
+        let second: Vec<_> = (500..1000).map(|i| data_info(i as f64)).collect();
+
+        assert_eq!(
+            chan.process_live_data(first, false),
+            BufferResult::Data(None)
+        );
+        assert_eq!(
+            chan.process_live_data(second, false),
+            BufferResult::Data(None)
+        );
+
+        // Buffer must hold all 1000 items.
+        let buf = chan.get_buffer().expect("buffer should not be empty");
+        assert_eq!(buf.len(), 1000);
+    }
+
+    // Adding one more item beyond 1000 triggers Overflow and clears the buffer.
+    #[test]
+    fn test_process_live_data_overflow_clears_buffer_and_returns_overflow() {
+        let mut chan = DataChannel::new();
+        // Fill to 1000.
+        let first: Vec<_> = (0..1000).map(|i| data_info(i as f64)).collect();
+        chan.process_live_data(first, false);
+
+        // One more item pushes it over the limit.
+        let result = chan.process_live_data(vec![data_info(9999.0)], false);
+        assert_eq!(result, BufferResult::Overflow);
+
+        // Buffer must have been cleared.
+        assert_eq!(chan.get_buffer(), None);
     }
 }

--- a/src/graphql/acsys/datastream/datamerge.rs
+++ b/src/graphql/acsys/datastream/datamerge.rs
@@ -59,11 +59,31 @@ where
     /// Filters out data points that have already been seen based on the
     /// `latest` timestamp and updates `latest` with the newest timestamp in
     /// the batch. Returns true if there is data left to emit.
+    ///
+    /// Status replies are passed through without updating the `latest`
+    /// watermark. Their timestamps are synthetic (wall-clock `now()`) and
+    /// have no relation to the device's actual data timeline; advancing
+    /// `latest` past them would cause subsequent real data points -- whose
+    /// hardware timestamps predate the synthetic one -- to be silently
+    /// discarded.
     fn filter_and_update_latest(
         data: &mut Vec<global::DataInfo>, latest: &mut f64,
     ) -> bool {
         if data.is_empty() {
             return false;
+        }
+
+        // If this packet is a single status reply, pass it through without
+        // touching the timestamp watermark.
+
+        if let [
+            global::DataInfo {
+                result: global::DataType::StatusReply(_),
+                ..
+            },
+        ] = data.as_slice()
+        {
+            return true;
         }
 
         let start = data.partition_point(|info| info.timestamp <= *latest);
@@ -337,6 +357,57 @@ mod test {
         let r = s.next().await.unwrap();
         assert_eq!(r.ref_id, 1);
         assert_eq!(r.data, vec![data_info(220.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    fn status_info(ts: f64) -> global::DataInfo {
+        global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::StatusReply(global::StatusReply {
+                status: -1,
+            }),
+        }
+    }
+
+    // Regression test: DPM sends a PEND status reply (with a synthetic
+    // wall-clock timestamp) before it sends the actual device data (whose
+    // hardware timestamp predates the synthetic one). The status packet must
+    // NOT advance the `latest` watermark, otherwise the subsequent real data
+    // points are silently discarded as "already seen".
+    #[tokio::test]
+    async fn test_status_reply_does_not_advance_watermark() {
+        use futures::stream::{self, StreamExt};
+
+        // Simulate: PEND status arrives at wall-clock time 1000.0, then
+        // real data arrives with a hardware timestamp of 120.0 (which is
+        // less than 1000.0 and would be filtered if the watermark were
+        // incorrectly advanced).
+        let live_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![status_info(1000.0)], // synthetic "now()" timestamp
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(120.0)], // real hardware timestamp
+            },
+        ];
+
+        let mut s = super::merge(
+            None::<stream::Empty<_>>,
+            Some(stream::iter(live_input)),
+        );
+
+        // The status reply must come through.
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 0);
+        assert_eq!(r.data, vec![status_info(1000.0)]);
+
+        // The real data must NOT be swallowed by the watermark.
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 0);
+        assert_eq!(r.data, vec![data_info(120.0)]);
 
         assert!(s.next().await.is_none());
     }

--- a/src/graphql/acsys/datastream/datamerge.rs
+++ b/src/graphql/acsys/datastream/datamerge.rs
@@ -210,7 +210,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::global;
+    use super::{DataMerge, global};
 
     fn data_info(ts: f64) -> global::DataInfo {
         global::DataInfo {
@@ -219,6 +219,156 @@ mod test {
                 scalar_value: ts / 2.0,
             }),
         }
+    }
+
+    fn status_info(ts: f64) -> global::DataInfo {
+        global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::StatusReply(global::StatusReply {
+                status: -1,
+            }),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // filter_and_update_latest unit tests (white-box)
+
+    // An empty vec returns false and leaves `latest` unchanged.
+    #[test]
+    fn test_filter_empty_vec_returns_false() {
+        let mut latest = 0.0_f64;
+        let mut data: Vec<global::DataInfo> = vec![];
+
+        assert!(!DataMerge::<
+            futures::stream::Empty<_>,
+            futures::stream::Empty<_>,
+        >::filter_and_update_latest(&mut data, &mut latest));
+        assert_eq!(latest, 0.0);
+    }
+
+    // All data points are at or below the watermark → all filtered, returns false.
+    #[test]
+    fn test_filter_all_duplicates_returns_false() {
+        let mut latest = 110.0_f64;
+        let mut data = vec![data_info(100.0), data_info(110.0)];
+
+        assert!(!DataMerge::<
+            futures::stream::Empty<_>,
+            futures::stream::Empty<_>,
+        >::filter_and_update_latest(&mut data, &mut latest));
+        assert!(data.is_empty());
+        // latest must not regress
+        assert_eq!(latest, 110.0);
+    }
+
+    // Some points are below the watermark, some above → partial filter.
+    #[test]
+    fn test_filter_partial_dedupe() {
+        let mut latest = 105.0_f64;
+        let mut data =
+            vec![data_info(100.0), data_info(105.0), data_info(110.0)];
+
+        assert!(DataMerge::<
+            futures::stream::Empty<_>,
+            futures::stream::Empty<_>,
+        >::filter_and_update_latest(&mut data, &mut latest));
+        assert_eq!(data, vec![data_info(110.0)]);
+        assert_eq!(latest, 110.0);
+    }
+
+    // All points are above the watermark → nothing filtered, watermark advances.
+    #[test]
+    fn test_filter_no_duplicates_advances_watermark() {
+        let mut latest = 50.0_f64;
+        let mut data = vec![data_info(60.0), data_info(70.0), data_info(80.0)];
+
+        assert!(DataMerge::<
+            futures::stream::Empty<_>,
+            futures::stream::Empty<_>,
+        >::filter_and_update_latest(&mut data, &mut latest));
+        assert_eq!(
+            data,
+            vec![data_info(60.0), data_info(70.0), data_info(80.0)]
+        );
+        assert_eq!(latest, 80.0);
+    }
+
+    // A single-element status reply passes through and does NOT advance the
+    // watermark (the regression guard).
+    #[test]
+    fn test_filter_status_reply_passes_through_without_advancing_watermark() {
+        let mut latest = 50.0_f64;
+        let mut data = vec![status_info(1000.0)];
+
+        assert!(DataMerge::<
+            futures::stream::Empty<_>,
+            futures::stream::Empty<_>,
+        >::filter_and_update_latest(&mut data, &mut latest));
+        // Status must be preserved.
+        assert_eq!(data, vec![status_info(1000.0)]);
+        // Watermark must NOT have advanced.
+        assert_eq!(latest, 50.0);
+    }
+
+    // A multi-element packet that happens to contain a status reply is NOT
+    // treated as a pure status packet — the normal timestamp path applies.
+    #[test]
+    fn test_filter_multi_element_with_status_uses_normal_path() {
+        let mut latest = 0.0_f64;
+        let mut data = vec![status_info(1000.0), data_info(10.0)];
+
+        assert!(DataMerge::<
+            futures::stream::Empty<_>,
+            futures::stream::Empty<_>,
+        >::filter_and_update_latest(&mut data, &mut latest));
+        // Both elements survive (both are above the watermark of 0.0).
+        assert_eq!(data, vec![status_info(1000.0), data_info(10.0)]);
+        // Watermark advances to the last element's timestamp.
+        assert_eq!(latest, 10.0);
+    }
+
+    // -----------------------------------------------------------------------
+    // merge() integration tests
+
+    // Both streams None → stream closes immediately.
+    #[tokio::test]
+    async fn test_merge_both_none() {
+        use futures::stream::{self, StreamExt};
+
+        let mut s = super::merge(
+            None::<stream::Empty<global::DataReply>>,
+            None::<stream::Empty<global::DataReply>>,
+        );
+        assert!(s.next().await.is_none());
+    }
+
+    // Archive-only (no live stream) — data passes through and stream closes.
+    #[tokio::test]
+    async fn test_merge_with_only_archive() {
+        use futures::stream::{self, StreamExt};
+
+        let archive_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(10.0), data_info(20.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(30.0)],
+            },
+        ];
+        let mut s = super::merge(
+            Some(stream::iter(archive_input)),
+            None::<stream::Empty<_>>,
+        );
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(10.0), data_info(20.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(30.0)]);
+
+        assert!(s.next().await.is_none());
     }
 
     #[tokio::test]
@@ -310,6 +460,89 @@ mod test {
         assert!(s.next().await.is_none());
     }
 
+    // Live data that arrives while the archive is still open must be buffered
+    // and released (in order) once the archive sentinel arrives.
+    #[tokio::test]
+    async fn test_live_data_buffered_until_archive_sentinel() {
+        use futures::stream::{self, StreamExt};
+
+        // Archive: one data packet then the sentinel.
+        // Live: two packets that arrive "concurrently" with the archive.
+        let archive_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(10.0), data_info(20.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![], // sentinel
+            },
+        ];
+        let live_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(30.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(40.0)],
+            },
+        ];
+        let mut s = super::merge(
+            Some(stream::iter(archive_input)),
+            Some(stream::iter(live_input)),
+        );
+
+        // Archive data comes first.
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(10.0), data_info(20.0)]);
+
+        // After the sentinel the buffered live data is released.
+        // The two live packets may be merged into one or emitted separately
+        // depending on how many poll cycles occur; collect all remaining items.
+        let mut all_data: Vec<global::DataInfo> = vec![];
+        while let Some(r) = s.next().await {
+            all_data.extend(r.data);
+        }
+        assert_eq!(all_data, vec![data_info(30.0), data_info(40.0)]);
+    }
+
+    // Live data whose timestamps exactly equal the watermark boundary must be
+    // filtered (the partition uses `<=`).
+    #[tokio::test]
+    async fn test_live_data_at_exact_watermark_is_filtered() {
+        use futures::stream::{self, StreamExt};
+
+        // Archive ends at 110.0; live sends 110.0 (duplicate) and 120.0 (new).
+        let archive_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(100.0), data_info(110.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![], // sentinel
+            },
+        ];
+        let live_input = [global::DataReply {
+            ref_id: 0,
+            data: vec![data_info(110.0), data_info(120.0)],
+        }];
+        let mut s = super::merge(
+            Some(stream::iter(archive_input)),
+            Some(stream::iter(live_input)),
+        );
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(100.0), data_info(110.0)]);
+
+        // 110.0 must be filtered; only 120.0 survives.
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(120.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
     #[tokio::test]
     async fn test_merge_multiple_ref_ids_dedupe() {
         use futures::stream::{self, StreamExt};
@@ -361,13 +594,90 @@ mod test {
         assert!(s.next().await.is_none());
     }
 
-    fn status_info(ts: f64) -> global::DataInfo {
-        global::DataInfo {
-            timestamp: ts,
-            result: global::DataType::StatusReply(global::StatusReply {
-                status: -1,
-            }),
-        }
+    // Multiple ref_ids with archive-only (no live stream).
+    #[tokio::test]
+    async fn test_merge_multiple_ref_ids_archive_only() {
+        use futures::stream::{self, StreamExt};
+
+        let archive_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(1.0), data_info(2.0)],
+            },
+            global::DataReply {
+                ref_id: 1,
+                data: vec![data_info(10.0), data_info(20.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(3.0)],
+            },
+        ];
+        let mut s = super::merge(
+            Some(stream::iter(archive_input)),
+            None::<stream::Empty<_>>,
+        );
+
+        let r0a = s.next().await.unwrap();
+        assert_eq!(r0a.ref_id, 0);
+        assert_eq!(r0a.data, vec![data_info(1.0), data_info(2.0)]);
+
+        let r1 = s.next().await.unwrap();
+        assert_eq!(r1.ref_id, 1);
+        assert_eq!(r1.data, vec![data_info(10.0), data_info(20.0)]);
+
+        let r0b = s.next().await.unwrap();
+        assert_eq!(r0b.ref_id, 0);
+        assert_eq!(r0b.data, vec![data_info(3.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // Multiple ref_ids with live-only (no archive stream).
+    #[tokio::test]
+    async fn test_merge_multiple_ref_ids_live_only() {
+        use futures::stream::{self, StreamExt};
+
+        let live_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(1.0)],
+            },
+            global::DataReply {
+                ref_id: 1,
+                data: vec![data_info(10.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(2.0)],
+            },
+            global::DataReply {
+                ref_id: 1,
+                data: vec![data_info(20.0)],
+            },
+        ];
+        let mut s = super::merge(
+            None::<stream::Empty<_>>,
+            Some(stream::iter(live_input)),
+        );
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 0);
+        assert_eq!(r.data, vec![data_info(1.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 1);
+        assert_eq!(r.data, vec![data_info(10.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 0);
+        assert_eq!(r.data, vec![data_info(2.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 1);
+        assert_eq!(r.data, vec![data_info(20.0)]);
+
+        assert!(s.next().await.is_none());
     }
 
     // Regression test: DPM sends a PEND status reply (with a synthetic
@@ -436,6 +746,79 @@ mod test {
 
         let r = s.next().await.unwrap();
         assert_eq!(r.data, vec![data_info(115.0)]);
+        assert!(s.next().await.is_none());
+    }
+
+    // A live packet whose entire data vec is at or below the watermark must
+    // be silently dropped (filter returns false → nothing emitted).
+    #[tokio::test]
+    async fn test_live_data_entirely_below_watermark_is_dropped() {
+        use futures::stream::{self, StreamExt};
+
+        // Archive establishes watermark at 200.0; live sends stale data.
+        let archive_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(100.0), data_info(200.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![], // sentinel
+            },
+        ];
+        let live_input = [
+            global::DataReply {
+                ref_id: 0,
+                // All of these are at or below the watermark of 200.0.
+                data: vec![data_info(150.0), data_info(200.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(300.0)], // this one is new
+            },
+        ];
+        let mut s = super::merge(
+            Some(stream::iter(archive_input)),
+            Some(stream::iter(live_input)),
+        );
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(100.0), data_info(200.0)]);
+
+        // The stale live packet must be silently dropped; only 300.0 arrives.
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(300.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // An archive stream that closes naturally (no sentinel) with no live
+    // stream — all data passes through and the merge stream closes.
+    #[tokio::test]
+    async fn test_archive_closes_naturally_no_live() {
+        use futures::stream::{self, StreamExt};
+
+        let archive_input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(5.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(10.0)],
+            },
+        ];
+        let mut s = super::merge(
+            Some(stream::iter(archive_input)),
+            None::<stream::Empty<_>>,
+        );
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(5.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(10.0)]);
+
         assert!(s.next().await.is_none());
     }
 }

--- a/src/graphql/acsys/datastream/endondate.rs
+++ b/src/graphql/acsys/datastream/endondate.rs
@@ -103,6 +103,9 @@ mod test {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Original tests (kept intact)
+
     #[tokio::test]
     async fn test_end_time() {
         use futures::stream::{self, StreamExt};
@@ -226,5 +229,290 @@ mod test {
         let mut s = super::end_stream_at(stream::pending(), 2, Some(115.0));
 
         assert!(s.next().now_or_never().is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // end_date = None (Either::Right pass-through path)
+
+    // With no end_date the stream is a transparent pass-through.
+    #[tokio::test]
+    async fn test_no_end_date_passes_all_data_through() {
+        use futures::stream::{self, StreamExt};
+
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(1.0), data_info(2.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(3.0)],
+            },
+        ];
+        let mut s = super::end_stream_at(stream::iter(input), 1, None);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(1.0), data_info(2.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(3.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // With no end_date and an empty source the stream closes immediately.
+    #[tokio::test]
+    async fn test_no_end_date_empty_source_closes_immediately() {
+        use futures::stream::{self, StreamExt};
+
+        let input: Vec<global::DataReply> = vec![];
+        let mut s = super::end_stream_at(stream::iter(input), 1, None);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty source stream
+
+    // An empty source with an end_date closes immediately.
+    #[tokio::test]
+    async fn test_empty_source_with_end_date_closes_immediately() {
+        use futures::stream::{self, StreamExt};
+
+        let input: Vec<global::DataReply> = vec![];
+        let mut s = super::end_stream_at(stream::iter(input), 1, Some(100.0));
+
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Single-device scenarios
+
+    // Single device, all data within end_date → all forwarded; stream closes
+    // when the source closes naturally.
+    #[tokio::test]
+    async fn test_single_device_all_within_end_date() {
+        use futures::stream::{self, StreamExt};
+
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(10.0), data_info(20.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(30.0)],
+            },
+        ];
+        let mut s = super::end_stream_at(stream::iter(input), 1, Some(100.0));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(10.0), data_info(20.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(30.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // Single device, first packet entirely exceeds end_date → data truncated
+    // to empty, device removed, stream closes immediately.
+    #[tokio::test]
+    async fn test_single_device_first_packet_entirely_beyond_end_date() {
+        use futures::stream::{self, StreamExt};
+
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                // All timestamps exceed end_date of 5.0.
+                data: vec![data_info(10.0), data_info(20.0)],
+            },
+            // Must never be delivered.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(30.0)],
+            },
+        ];
+        let mut s = super::end_stream_at(stream::iter(input), 1, Some(5.0));
+
+        // The packet is truncated to empty → device removed → stream closes.
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Timestamp boundary tests
+
+    // A timestamp exactly equal to end_date must be included (`<=`).
+    #[tokio::test]
+    async fn test_timestamp_exactly_at_end_date_is_included() {
+        use futures::stream::{self, StreamExt};
+
+        let input = [global::DataReply {
+            ref_id: 0,
+            data: vec![data_info(100.0), data_info(115.0)],
+        }];
+        let mut s = super::end_stream_at(stream::iter(input), 1, Some(115.0));
+
+        let r = s.next().await.unwrap();
+        // Both points must be present (115.0 == end_date).
+        assert_eq!(r.data, vec![data_info(100.0), data_info(115.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // A timestamp one epsilon above end_date must be excluded.
+    #[tokio::test]
+    async fn test_timestamp_just_above_end_date_is_excluded() {
+        use futures::stream::{self, StreamExt};
+
+        let end = 115.0_f64;
+        let just_above = end + f64::EPSILON * end; // next representable f64 above 115.0
+
+        let input = [global::DataReply {
+            ref_id: 0,
+            data: vec![data_info(100.0), data_info(just_above)],
+        }];
+        let mut s = super::end_stream_at(stream::iter(input), 1, Some(end));
+
+        let r = s.next().await.unwrap();
+        // Only 100.0 survives; just_above is truncated.
+        assert_eq!(r.data, vec![data_info(100.0)]);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-device scenarios
+
+    // Two devices: device 0 exceeds end_date first; stream stays open until
+    // device 1 also exceeds it.
+    #[tokio::test]
+    async fn test_two_devices_one_exceeds_before_other() {
+        use futures::stream::{self, StreamExt};
+
+        let input = [
+            // Device 0 exceeds end_date immediately.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(200.0)],
+            },
+            // Device 1 still has valid data.
+            global::DataReply {
+                ref_id: 1,
+                data: vec![data_info(50.0), data_info(100.0)],
+            },
+            // Device 1 now exceeds end_date → stream closes.
+            global::DataReply {
+                ref_id: 1,
+                data: vec![data_info(200.0)],
+            },
+            // Must never be delivered.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(300.0)],
+            },
+        ];
+        let mut s = super::end_stream_at(stream::iter(input), 2, Some(150.0));
+
+        // Device 0's packet is entirely beyond end_date → silently dropped.
+        // Device 1's first packet passes through.
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 1);
+        assert_eq!(r.data, vec![data_info(50.0), data_info(100.0)]);
+
+        // Device 1's second packet exceeds end_date → both devices done → close.
+        assert!(s.next().await.is_none());
+    }
+
+    // A packet that is partially within and partially beyond end_date is
+    // truncated at the boundary.
+    #[tokio::test]
+    async fn test_partial_packet_truncated_at_end_date() {
+        use futures::stream::{self, StreamExt};
+
+        let input = [global::DataReply {
+            ref_id: 0,
+            data: vec![
+                data_info(10.0),
+                data_info(20.0),
+                data_info(30.0), // beyond end_date of 25.0
+                data_info(40.0), // beyond end_date of 25.0
+            ],
+        }];
+        let mut s = super::end_stream_at(stream::iter(input), 1, Some(25.0));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(10.0), data_info(20.0)]);
+
+        // Device 0 is now done → stream closes.
+        assert!(s.next().await.is_none());
+    }
+
+    // Source closes naturally before any device exceeds end_date → stream
+    // closes too (the `Poll::Ready(None)` arm).
+    #[tokio::test]
+    async fn test_source_closes_naturally_before_end_date() {
+        use futures::stream::{self, StreamExt};
+
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(1.0)],
+            },
+            global::DataReply {
+                ref_id: 1,
+                data: vec![data_info(2.0)],
+            },
+        ];
+        // end_date is far in the future — source will close first.
+        let mut s = super::end_stream_at(stream::iter(input), 2, Some(9999.0));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 0);
+        assert_eq!(r.data, vec![data_info(1.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.ref_id, 1);
+        assert_eq!(r.data, vec![data_info(2.0)]);
+
+        // Source exhausted → stream closes.
+        assert!(s.next().await.is_none());
+    }
+
+    // A device sends multiple packets all within end_date, then one that
+    // exceeds it — only the exceeding packet triggers device removal.
+    #[tokio::test]
+    async fn test_device_sends_multiple_valid_packets_then_exceeds() {
+        use futures::stream::{self, StreamExt};
+
+        let input = [
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(10.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(20.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(30.0)],
+            },
+            // This packet exceeds end_date of 25.0.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![data_info(40.0)],
+            },
+        ];
+        let mut s = super::end_stream_at(stream::iter(input), 1, Some(25.0));
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(10.0)]);
+
+        let r = s.next().await.unwrap();
+        assert_eq!(r.data, vec![data_info(20.0)]);
+
+        // 30.0 > 25.0 → truncated to empty → device removed → stream closes.
+        assert!(s.next().await.is_none());
     }
 }

--- a/src/graphql/acsys/datastream/groupscalars.rs
+++ b/src/graphql/acsys/datastream/groupscalars.rs
@@ -218,6 +218,18 @@ mod test {
         }
     }
 
+    fn status_info(ts: f64) -> global::DataInfo {
+        global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::StatusReply(global::StatusReply {
+                status: -1,
+            }),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Waveform tests
+
     #[tokio::test]
     async fn test_grouping_waveforms() {
         use futures::stream::{self, StreamExt};
@@ -260,7 +272,32 @@ mod test {
                 data: vec![waveform_info(120.0), waveform_info(130.0)]
             },
         );
+        assert!(s.next().await.is_none());
     }
+
+    // A single waveform packet is forwarded and the stream closes.
+    #[tokio::test]
+    async fn test_single_waveform() {
+        use futures::stream::{self, StreamExt};
+
+        let input = &[global::DataReply {
+            ref_id: 3,
+            data: vec![waveform_info(50.0)],
+        }];
+        let mut s = super::group_scalars::<4, _>(stream::iter(input.clone()));
+
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 3,
+                data: vec![waveform_info(50.0)]
+            },
+        );
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Scalar tests
 
     #[tokio::test]
     async fn test_grouping_scalars() {
@@ -306,5 +343,369 @@ mod test {
                 data: vec![scalar_info(140.0),]
             },
         );
+        assert!(s.next().await.is_none());
+    }
+
+    // A single scalar is held in the pending buffer and flushed when the
+    // source stream closes.
+    #[tokio::test]
+    async fn test_single_scalar_flushed_on_close() {
+        use futures::stream::{self, StreamExt};
+
+        let input = &[global::DataReply {
+            ref_id: 7,
+            data: vec![scalar_info(42.0)],
+        }];
+        let mut s = super::group_scalars::<4, _>(stream::iter(input.clone()));
+
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 7,
+                data: vec![scalar_info(42.0)]
+            },
+        );
+        assert!(s.next().await.is_none());
+    }
+
+    // Scalars that accumulate to exactly MAX_PAYLOAD are emitted as one
+    // chunk; the stream then closes without a trailing flush.
+    #[tokio::test]
+    async fn test_scalars_fill_exactly_max_payload() {
+        use futures::stream::{self, StreamExt};
+
+        // 4 individual packets → one full chunk of 4, nothing left over.
+        let input: Vec<global::DataReply> = (0..4)
+            .map(|i| global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(i as f64 * 10.0)],
+            })
+            .collect();
+        let mut s = super::group_scalars::<4, _>(stream::iter(input));
+
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![
+                    scalar_info(0.0),
+                    scalar_info(10.0),
+                    scalar_info(20.0),
+                    scalar_info(30.0),
+                ]
+            },
+        );
+        // No leftover — stream should be done.
+        assert!(s.next().await.is_none());
+    }
+
+    // The very first packet already contains MAX_PAYLOAD scalars. It must be
+    // emitted immediately (the `>= MAX_PAYLOAD` branch in Unknown state).
+    #[tokio::test]
+    async fn test_first_packet_exactly_max_payload() {
+        use futures::stream::{self, StreamExt};
+
+        let input = &[global::DataReply {
+            ref_id: 0,
+            data: vec![
+                scalar_info(1.0),
+                scalar_info(2.0),
+                scalar_info(3.0),
+                scalar_info(4.0),
+            ],
+        }];
+        let mut s = super::group_scalars::<4, _>(stream::iter(input.clone()));
+
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![
+                    scalar_info(1.0),
+                    scalar_info(2.0),
+                    scalar_info(3.0),
+                    scalar_info(4.0),
+                ]
+            },
+        );
+        // The pending buffer is now empty; stream closes cleanly.
+        assert!(s.next().await.is_none());
+    }
+
+    // The very first packet contains MORE than MAX_PAYLOAD scalars. The
+    // excess must be retained and emitted in a subsequent chunk.
+    #[tokio::test]
+    async fn test_first_packet_exceeds_max_payload() {
+        use futures::stream::{self, StreamExt};
+
+        // 6 scalars in one shot with MAX_PAYLOAD = 4.
+        let input = &[global::DataReply {
+            ref_id: 0,
+            data: vec![
+                scalar_info(1.0),
+                scalar_info(2.0),
+                scalar_info(3.0),
+                scalar_info(4.0),
+                scalar_info(5.0),
+                scalar_info(6.0),
+            ],
+        }];
+        let mut s = super::group_scalars::<4, _>(stream::iter(input.clone()));
+
+        // First chunk: the first MAX_PAYLOAD items.
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![
+                    scalar_info(1.0),
+                    scalar_info(2.0),
+                    scalar_info(3.0),
+                    scalar_info(4.0),
+                ]
+            },
+        );
+        // Remaining 2 items flushed when the source closes.
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(5.0), scalar_info(6.0),]
+            },
+        );
+        assert!(s.next().await.is_none());
+    }
+
+    // A payload that is much larger than MAX_PAYLOAD is split only once
+    // during the Unknown→Scalar transition: the first MAX_PAYLOAD items are
+    // emitted immediately and the remainder is stored as pending. When the
+    // source stream closes, the entire pending buffer is flushed as a single
+    // chunk (the implementation does not re-split on flush).
+    #[tokio::test]
+    async fn test_large_single_packet_multiple_chunks() {
+        use futures::stream::{self, StreamExt};
+
+        // 10 scalars in one packet, MAX_PAYLOAD = 3.
+        // Poll 1 (Unknown state): emits [0,1,2], stores [3..9] as pending.
+        // Poll 2 (stream closes): flushes all 7 remaining items as one chunk.
+        let input = &[global::DataReply {
+            ref_id: 0,
+            data: (0..10).map(|i| scalar_info(i as f64)).collect(),
+        }];
+        let mut s = super::group_scalars::<3, _>(stream::iter(input.clone()));
+
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![
+                    scalar_info(0.0),
+                    scalar_info(1.0),
+                    scalar_info(2.0),
+                ]
+            },
+        );
+        // The remaining 7 items are flushed as a single chunk when the source
+        // stream closes — the implementation does not re-split pending data.
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: (3..10)
+                    .map(|i| scalar_info(i as f64))
+                    .collect::<Vec<_>>()
+            },
+        );
+        assert!(s.next().await.is_none());
+    }
+
+    // With MAX_PAYLOAD = 1 every scalar must be emitted immediately.
+    #[tokio::test]
+    async fn test_max_payload_one_emits_each_scalar_immediately() {
+        use futures::stream::{self, StreamExt};
+
+        let input: Vec<global::DataReply> = (0..4)
+            .map(|i| global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(i as f64 * 5.0)],
+            })
+            .collect();
+        let mut s = super::group_scalars::<1, _>(stream::iter(input));
+
+        for i in 0..4u32 {
+            assert_eq!(
+                s.next().await.unwrap(),
+                global::DataReply {
+                    ref_id: 0,
+                    data: vec![scalar_info(i as f64 * 5.0)]
+                },
+            );
+        }
+        assert!(s.next().await.is_none());
+    }
+
+    // The ref_id from the first packet must be preserved in all emitted
+    // chunks, even when data spans multiple source packets.
+    #[tokio::test]
+    async fn test_ref_id_is_preserved() {
+        use futures::stream::{self, StreamExt};
+
+        let input: Vec<global::DataReply> = (0..6)
+            .map(|i| global::DataReply {
+                ref_id: 42,
+                data: vec![scalar_info(i as f64)],
+            })
+            .collect();
+        let mut s = super::group_scalars::<4, _>(stream::iter(input));
+
+        let chunk1 = s.next().await.unwrap();
+        assert_eq!(chunk1.ref_id, 42);
+        assert_eq!(chunk1.data.len(), 4);
+
+        let chunk2 = s.next().await.unwrap();
+        assert_eq!(chunk2.ref_id, 42);
+        assert_eq!(chunk2.data.len(), 2);
+
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty / degenerate stream tests
+
+    // An empty source stream must produce no items.
+    #[tokio::test]
+    async fn test_empty_stream() {
+        use futures::stream::{self, StreamExt};
+
+        let input: Vec<global::DataReply> = vec![];
+        let mut s = super::group_scalars::<4, _>(stream::iter(input));
+
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Unknown / unsupported data-type tests
+
+    // A packet whose first element is neither Scalar nor ScalarArray must
+    // cause the stream to terminate immediately.
+    #[tokio::test]
+    async fn test_unknown_data_type_terminates_stream() {
+        use futures::stream::{self, StreamExt};
+
+        let input = &[
+            global::DataReply {
+                ref_id: 0,
+                data: vec![status_info(1.0)],
+            },
+            // This packet should never be reached.
+            global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(2.0)],
+            },
+        ];
+        let mut s = super::group_scalars::<4, _>(stream::iter(input.clone()));
+
+        // The stream must close without yielding any item.
+        assert!(s.next().await.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Boundary / accumulation tests
+
+    // Two packets that together exactly fill MAX_PAYLOAD, followed by one
+    // more packet — verifies the boundary between a full chunk and a flush.
+    #[tokio::test]
+    async fn test_two_packets_fill_then_one_more() {
+        use futures::stream::{self, StreamExt};
+
+        // MAX_PAYLOAD = 4; first two packets contribute 2 each (fills buffer),
+        // third packet contributes 1 (flushed on close).
+        let input = &[
+            global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(1.0), scalar_info(2.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(3.0), scalar_info(4.0)],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(5.0)],
+            },
+        ];
+        let mut s = super::group_scalars::<4, _>(stream::iter(input.clone()));
+
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![
+                    scalar_info(1.0),
+                    scalar_info(2.0),
+                    scalar_info(3.0),
+                    scalar_info(4.0),
+                ]
+            },
+        );
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(5.0)]
+            },
+        );
+        assert!(s.next().await.is_none());
+    }
+
+    // An incoming packet that would overflow the pending buffer must be split:
+    // the portion that fits is appended to the pending buffer (which is then
+    // emitted), and the remainder becomes the new pending buffer.
+    #[tokio::test]
+    async fn test_overflow_packet_splits_correctly() {
+        use futures::stream::{self, StreamExt};
+
+        // Pending has 3 items; next packet has 3 items; MAX_PAYLOAD = 4.
+        // Expected: emit [a,b,c,d], then flush [e,f].
+        let input = &[
+            global::DataReply {
+                ref_id: 0,
+                data: vec![
+                    scalar_info(1.0),
+                    scalar_info(2.0),
+                    scalar_info(3.0),
+                ],
+            },
+            global::DataReply {
+                ref_id: 0,
+                data: vec![
+                    scalar_info(4.0),
+                    scalar_info(5.0),
+                    scalar_info(6.0),
+                ],
+            },
+        ];
+        let mut s = super::group_scalars::<4, _>(stream::iter(input.clone()));
+
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![
+                    scalar_info(1.0),
+                    scalar_info(2.0),
+                    scalar_info(3.0),
+                    scalar_info(4.0),
+                ]
+            },
+        );
+        assert_eq!(
+            s.next().await.unwrap(),
+            global::DataReply {
+                ref_id: 0,
+                data: vec![scalar_info(5.0), scalar_info(6.0),]
+            },
+        );
+        assert!(s.next().await.is_none());
     }
 }

--- a/src/graphql/acsys/mod.rs
+++ b/src/graphql/acsys/mod.rs
@@ -1254,6 +1254,9 @@ correlated, all the devices are collected on the same event."]
 mod test {
     use super::*;
 
+    // -----------------------------------------------------------------------
+    // strip_event
+
     #[test]
     fn test_removing_event() {
         use super::strip_event;
@@ -1266,6 +1269,35 @@ mod test {
         assert_eq!(strip_event("@"), "");
         assert_eq!(strip_event(" @"), "");
     }
+
+    // Multiple `@` characters — only the first one is the delimiter.
+    #[test]
+    fn test_removing_event_multiple_at_signs() {
+        use super::strip_event;
+
+        assert_eq!(strip_event("abc@e,23@extra"), "abc");
+    }
+
+    // Trailing whitespace before `@` is trimmed.
+    #[test]
+    fn test_removing_event_trailing_whitespace_trimmed() {
+        use super::strip_event;
+
+        assert_eq!(strip_event("M:OUTTMP  @p,1000000u"), "M:OUTTMP");
+        assert_eq!(strip_event("M:OUTTMP\t@p,1000000u"), "M:OUTTMP");
+    }
+
+    // A DRF with a source specifier but no event — strip_event leaves the
+    // source part intact.
+    #[test]
+    fn test_removing_event_leaves_source_intact() {
+        use super::strip_event;
+
+        assert_eq!(strip_event("abc<-LOGGER"), "abc<-LOGGER");
+    }
+
+    // -----------------------------------------------------------------------
+    // strip_source
 
     #[test]
     fn test_removing_source() {
@@ -1285,6 +1317,17 @@ mod test {
         assert_eq!(strip_source("abc@e,23 <-JUNK<-MOREJUNK"), "abc@e,23");
     }
 
+    // strip_source on a string with only a source specifier.
+    #[test]
+    fn test_removing_source_only_source() {
+        use super::strip_source;
+
+        assert_eq!(strip_source("<-LOGGER"), "");
+    }
+
+    // -----------------------------------------------------------------------
+    // device_name
+
     #[test]
     fn test_getting_device_name() {
         use super::device_name;
@@ -1295,6 +1338,50 @@ mod test {
         assert_eq!(device_name("abc<-LOGGER"), "abc");
         assert_eq!(device_name("abc.READING"), "abc.READING");
     }
+
+    // Empty string returns empty string.
+    #[test]
+    fn test_getting_device_name_empty() {
+        use super::device_name;
+
+        assert_eq!(device_name(""), "");
+    }
+
+    // Trailing whitespace before the delimiter is trimmed.
+    #[test]
+    fn test_getting_device_name_trailing_whitespace_trimmed() {
+        use super::device_name;
+
+        assert_eq!(device_name("M:OUTTMP @e,2"), "M:OUTTMP");
+        assert_eq!(device_name("M:OUTTMP <-LOGGER"), "M:OUTTMP");
+    }
+
+    // A subscript followed by an event — the subscript is part of the name.
+    #[test]
+    fn test_getting_device_name_subscript_with_event() {
+        use super::device_name;
+
+        assert_eq!(device_name("abc[3]@e,2"), "abc[3]");
+    }
+
+    // A subscript followed by a source — the subscript is part of the name.
+    #[test]
+    fn test_getting_device_name_subscript_with_source() {
+        use super::device_name;
+
+        assert_eq!(device_name("abc[3]<-LOGGER"), "abc[3]");
+    }
+
+    // Both `@` and `<` present — the first delimiter wins.
+    #[test]
+    fn test_getting_device_name_event_before_source() {
+        use super::device_name;
+
+        assert_eq!(device_name("abc@e,2<-LOGGER"), "abc");
+    }
+
+    // -----------------------------------------------------------------------
+    // add_event
 
     #[test]
     fn test_add_event_specification() {
@@ -1317,6 +1404,58 @@ mod test {
             "M:OUTTMP@e,8F,e,13"
         );
     }
+
+    // delay=Some(0) is treated as "no delay" → falls back to 1_000_000 µs.
+    #[test]
+    fn test_add_event_zero_delay_uses_default() {
+        use super::add_event;
+
+        assert_eq!(add_event(Some(0), None)("M:OUTTMP"), "M:OUTTMP@p,1000000u");
+    }
+
+    // Rounding boundary: 499 µs rounds down to 0 ms.
+    #[test]
+    fn test_add_event_delay_rounds_down() {
+        use super::add_event;
+
+        assert_eq!(
+            add_event(Some(499), Some(0x01))("M:OUTTMP"),
+            "M:OUTTMP@e,1,e,0"
+        );
+    }
+
+    // Rounding boundary: 500 µs rounds up to 1 ms.
+    #[test]
+    fn test_add_event_delay_rounds_up() {
+        use super::add_event;
+
+        assert_eq!(
+            add_event(Some(500), Some(0x01))("M:OUTTMP"),
+            "M:OUTTMP@e,1,e,1"
+        );
+    }
+
+    // Event code 0x0F is formatted in uppercase hex.
+    #[test]
+    fn test_add_event_hex_formatting() {
+        use super::add_event;
+
+        assert_eq!(add_event(None, Some(0x0f))("M:OUTTMP"), "M:OUTTMP@e,F,e");
+        assert_eq!(add_event(None, Some(0xff))("M:OUTTMP"), "M:OUTTMP@e,FF,e");
+    }
+
+    // The closure can be applied to different device names.
+    #[test]
+    fn test_add_event_closure_reusable() {
+        use super::add_event;
+
+        let ev = add_event(Some(2000), None);
+        assert_eq!(ev("M:OUTTMP"), "M:OUTTMP@p,2000u");
+        assert_eq!(ev("G:AMANDA"), "G:AMANDA@p,2000u");
+    }
+
+    // -----------------------------------------------------------------------
+    // flush
 
     #[test]
     fn test_flush() {
@@ -1381,6 +1520,136 @@ mod test {
         assert_eq!(buf.trigger_timestamp, None);
         assert!(buf.data[0].channel_data.is_empty());
     }
+
+    // flush on an already-empty channel_data is a no-op.
+    #[test]
+    fn test_flush_empty_channel_data_is_noop() {
+        let mut buf = types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: Some(42.0),
+            data: vec![types::PlotChannelData {
+                channel_rate: "Unknown".into(),
+                channel_units: "V".to_owned(),
+                status_string: None,
+                channel_status: 0,
+                channel_data: vec![],
+            }],
+        };
+
+        ACSysSubscriptions::flush(&mut buf, 5.0);
+
+        // trigger_timestamp is always reset to None.
+        assert_eq!(buf.trigger_timestamp, None);
+        assert!(buf.data[0].channel_data.is_empty());
+    }
+
+    // flush resets trigger_timestamp to None regardless of its prior value.
+    #[test]
+    fn test_flush_resets_trigger_timestamp() {
+        let mut buf = types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: Some(99.0),
+            data: vec![types::PlotChannelData {
+                channel_rate: "Unknown".into(),
+                channel_units: "V".to_owned(),
+                status_string: None,
+                channel_status: 0,
+                channel_data: vec![global::DataInfo {
+                    timestamp: 1.0,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 0.5,
+                    }),
+                }],
+            }],
+        };
+
+        ACSysSubscriptions::flush(&mut buf, 0.0);
+        assert_eq!(buf.trigger_timestamp, None);
+    }
+
+    // flush with a timestamp exactly equal to a data point's timestamp
+    // removes that point (partition_point uses `<`, so equal timestamps
+    // are NOT removed — they remain).
+    #[test]
+    fn test_flush_timestamp_exactly_at_data_point() {
+        let point = global::DataInfo {
+            timestamp: 3.0,
+            result: global::DataType::Scalar(global::Scalar {
+                scalar_value: 1.5,
+            }),
+        };
+        let mut buf = types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: None,
+            data: vec![types::PlotChannelData {
+                channel_rate: "Unknown".into(),
+                channel_units: "V".to_owned(),
+                status_string: None,
+                channel_status: 0,
+                channel_data: vec![point.clone()],
+            }],
+        };
+
+        // ts == point.timestamp → partition_point returns 0 (not < 3.0) →
+        // nothing is drained → point survives.
+        ACSysSubscriptions::flush(&mut buf, 3.0);
+        assert_eq!(buf.data[0].channel_data, vec![point]);
+    }
+
+    // flush operates independently on each channel.
+    #[test]
+    fn test_flush_multiple_channels() {
+        let make_point = |ts: f64| global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::Scalar(global::Scalar {
+                scalar_value: ts / 2.0,
+            }),
+        };
+        let mut buf = types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: None,
+            data: vec![
+                types::PlotChannelData {
+                    channel_rate: "Unknown".into(),
+                    channel_units: "V".to_owned(),
+                    status_string: None,
+                    channel_status: 0,
+                    channel_data: vec![
+                        make_point(1.0),
+                        make_point(2.0),
+                        make_point(3.0),
+                    ],
+                },
+                types::PlotChannelData {
+                    channel_rate: "Unknown".into(),
+                    channel_units: "A".to_owned(),
+                    status_string: None,
+                    channel_status: 0,
+                    channel_data: vec![make_point(10.0), make_point(20.0)],
+                },
+            ],
+        };
+
+        // Flush at ts=1.5: removes point at 1.0 from channel 0; channel 1
+        // has no points below 1.5 so it is unchanged.
+        ACSysSubscriptions::flush(&mut buf, 1.5);
+
+        assert_eq!(
+            buf.data[0].channel_data,
+            vec![make_point(2.0), make_point(3.0)]
+        );
+        assert_eq!(
+            buf.data[1].channel_data,
+            vec![make_point(10.0), make_point(20.0)]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // prep_outgoing
 
     #[test]
     fn test_partitioning() {
@@ -1608,5 +1877,152 @@ mod test {
             ]
         );
         assert!(rem.data[0].channel_data.is_empty());
+    }
+
+    // prep_outgoing with empty channel_data in both buffers — nothing moves,
+    // trigger_timestamp is still set.
+    #[test]
+    fn test_prep_outgoing_empty_channels() {
+        let make_buf = || types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: None,
+            data: vec![types::PlotChannelData {
+                channel_rate: "Unknown".into(),
+                channel_units: "V".to_owned(),
+                status_string: None,
+                channel_status: 0,
+                channel_data: vec![],
+            }],
+        };
+
+        let mut out = make_buf();
+        let mut rem = make_buf();
+
+        ACSysSubscriptions::prep_outgoing(&mut rem, &mut out, 5.0, 10.0);
+
+        assert_eq!(out.trigger_timestamp, Some(5.0));
+        assert!(out.data[0].channel_data.is_empty());
+        assert!(rem.data[0].channel_data.is_empty());
+    }
+
+    // prep_outgoing sets trigger_timestamp to ev_ts on the outgoing buffer.
+    #[test]
+    fn test_prep_outgoing_sets_trigger_timestamp() {
+        let make_point = |ts: f64| global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::Scalar(global::Scalar {
+                scalar_value: ts / 2.0,
+            }),
+        };
+        let mut out = types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: None,
+            data: vec![types::PlotChannelData {
+                channel_rate: "Unknown".into(),
+                channel_units: "V".to_owned(),
+                status_string: None,
+                channel_status: 0,
+                channel_data: vec![make_point(1.0), make_point(2.0)],
+            }],
+        };
+        let mut rem = out.clone();
+
+        ACSysSubscriptions::prep_outgoing(&mut rem, &mut out, 42.0, 100.0);
+
+        assert_eq!(out.trigger_timestamp, Some(42.0));
+    }
+
+    // prep_outgoing with ts beyond all data — everything moves to `out`,
+    // `rem` is left empty.
+    #[test]
+    fn test_prep_outgoing_ts_beyond_all_data() {
+        let make_point = |ts: f64| global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::Scalar(global::Scalar {
+                scalar_value: ts / 2.0,
+            }),
+        };
+        let mut out = types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: None,
+            data: vec![types::PlotChannelData {
+                channel_rate: "Unknown".into(),
+                channel_units: "V".to_owned(),
+                status_string: None,
+                channel_status: 0,
+                channel_data: vec![
+                    make_point(1.0),
+                    make_point(2.0),
+                    make_point(3.0),
+                ],
+            }],
+        };
+        let mut rem = out.clone();
+
+        // ts = 9999.0 is beyond all data → all points go to out, rem is empty.
+        ACSysSubscriptions::prep_outgoing(&mut rem, &mut out, 10.0, 9999.0);
+
+        assert!(rem.data[0].channel_data.is_empty());
+        // Timestamps are shifted by ev_ts (10.0).
+        assert_eq!(
+            out.data[0].channel_data,
+            vec![
+                global::DataInfo {
+                    timestamp: -9.0,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 0.5,
+                    }),
+                },
+                global::DataInfo {
+                    timestamp: -8.0,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 1.0,
+                    }),
+                },
+                global::DataInfo {
+                    timestamp: -7.0,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 1.5,
+                    }),
+                },
+            ]
+        );
+    }
+
+    // prep_outgoing with ts before all data — nothing moves to out, all
+    // data stays in rem.
+    #[test]
+    fn test_prep_outgoing_ts_before_all_data() {
+        let make_point = |ts: f64| global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::Scalar(global::Scalar {
+                scalar_value: ts / 2.0,
+            }),
+        };
+        let mut out = types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: None,
+            data: vec![types::PlotChannelData {
+                channel_rate: "Unknown".into(),
+                channel_units: "V".to_owned(),
+                status_string: None,
+                channel_status: 0,
+                channel_data: vec![make_point(10.0), make_point(20.0)],
+            }],
+        };
+        let mut rem = out.clone();
+
+        // ts = 0.0 is before all data → nothing partitioned into out.
+        ACSysSubscriptions::prep_outgoing(&mut rem, &mut out, 5.0, 0.0);
+
+        assert!(out.data[0].channel_data.is_empty());
+        assert_eq!(
+            rem.data[0].channel_data,
+            vec![make_point(10.0), make_point(20.0)]
+        );
     }
 }

--- a/src/graphql/acsys/mod.rs
+++ b/src/graphql/acsys/mod.rs
@@ -250,7 +250,7 @@ want to set."]
     ) -> Result<global::StatusReply> {
         if let Ok(auth) = _ctxt.data::<global::AuthInfo>() {
             let now = tokio::time::Instant::now();
-            let result = dpm::_set_device(
+            let result = dpm::set_device(
                 _ctxt.data::<Connection>().unwrap(),
                 auth.token(),
                 device.clone(),

--- a/src/graphql/acsys/mod.rs
+++ b/src/graphql/acsys/mod.rs
@@ -869,6 +869,10 @@ impl<'ctx> ACSysSubscriptions {
                 .channel_data
                 .extend(out_chan.channel_data.drain(idx..));
 
+            out_chan.channel_data.retain(|v| {
+                !matches!(v.result, global::DataType::StatusReply(_))
+            });
+
             for out_data in out_chan.channel_data.iter_mut() {
                 out_data.timestamp -= ev_ts;
             }
@@ -1463,6 +1467,123 @@ mod test {
             ],
         );
         assert_eq!(rem.data[0].channel_data, &POINT_DATA[3..]);
+
+        buf = rem.clone();
+
+        ACSysSubscriptions::prep_outgoing(&mut rem, &mut buf, 0.5, 10.0);
+
+        assert_eq!(buf.trigger_timestamp, Some(0.5));
+        assert_eq!(
+            buf.data[0].channel_data,
+            &[
+                global::DataInfo {
+                    timestamp: 3.5,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 13.0,
+                    }),
+                },
+                global::DataInfo {
+                    timestamp: 4.5,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 14.0,
+                    }),
+                },
+            ]
+        );
+        assert!(rem.data[0].channel_data.is_empty());
+    }
+
+    #[test]
+    fn test_partitioning_with_status() {
+        const POINT_DATA: &[global::DataInfo] = &[
+            global::DataInfo {
+                timestamp: 0.75,
+                result: global::DataType::StatusReply(global::StatusReply {
+                    status: -17 * 256 + 17,
+                }),
+            },
+            global::DataInfo {
+                timestamp: 1.0,
+                result: global::DataType::Scalar(global::Scalar {
+                    scalar_value: 10.0,
+                }),
+            },
+            global::DataInfo {
+                timestamp: 2.0,
+                result: global::DataType::Scalar(global::Scalar {
+                    scalar_value: 11.0,
+                }),
+            },
+            global::DataInfo {
+                timestamp: 3.0,
+                result: global::DataType::Scalar(global::Scalar {
+                    scalar_value: 12.0,
+                }),
+            },
+            global::DataInfo {
+                timestamp: 4.0,
+                result: global::DataType::Scalar(global::Scalar {
+                    scalar_value: 13.0,
+                }),
+            },
+            global::DataInfo {
+                timestamp: 5.0,
+                result: global::DataType::Scalar(global::Scalar {
+                    scalar_value: 14.0,
+                }),
+            },
+        ];
+
+        let mut buf = types::PlotReplyData {
+            plot_id: "test".to_owned(),
+            timestamp: 0.0,
+            trigger_timestamp: None,
+            data: vec![types::PlotChannelData {
+                channel_rate: "Unknown".into(),
+                channel_units: "V".to_owned(),
+                status_string: None,
+                channel_status: 0,
+                channel_data: POINT_DATA.to_owned(),
+            }],
+        };
+
+        let mut rem = buf.clone();
+
+        ACSysSubscriptions::prep_outgoing(&mut rem, &mut buf, 0.5, 0.0);
+
+        assert!(buf.data[0].channel_data.is_empty());
+        assert_eq!(buf.trigger_timestamp, Some(0.5));
+        assert_eq!(rem.data[0].channel_data, POINT_DATA);
+
+        buf = rem.clone();
+
+        ACSysSubscriptions::prep_outgoing(&mut rem, &mut buf, 0.5, 3.5);
+
+        assert_eq!(buf.trigger_timestamp, Some(0.5));
+        assert_eq!(
+            buf.data[0].channel_data,
+            &[
+                global::DataInfo {
+                    timestamp: 0.5,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 10.0,
+                    }),
+                },
+                global::DataInfo {
+                    timestamp: 1.5,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 11.0,
+                    }),
+                },
+                global::DataInfo {
+                    timestamp: 2.5,
+                    result: global::DataType::Scalar(global::Scalar {
+                        scalar_value: 12.0,
+                    }),
+                }
+            ],
+        );
+        assert_eq!(rem.data[0].channel_data, &POINT_DATA[4..]);
 
         buf = rem.clone();
 

--- a/src/graphql/alarms/mod.rs
+++ b/src/graphql/alarms/mod.rs
@@ -239,16 +239,15 @@ fn handle_error<T>(e: Status, gerund: &str) -> Result<T, Error> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "kafka")]
-    use std::time::Duration;
-
-    use async_graphql::{EmptySubscription, Schema};
+    use async_graphql::Schema;
     #[cfg(feature = "kafka")]
     use rust_pubsub_lib::{
         KafkaPublisher, KafkaTestHarness, Message, Publisher,
     };
     #[cfg(feature = "kafka")]
     use serde_json::json;
+    #[cfg(feature = "kafka")]
+    use std::time::Duration;
     #[cfg(feature = "kafka")]
     use tokio::time::timeout;
 

--- a/src/graphql/alarms/mod.rs
+++ b/src/graphql/alarms/mod.rs
@@ -260,7 +260,7 @@ mod tests {
         #[cfg(feature = "kafka")]
         let subscription = AlarmsSubscriptions::default();
         #[cfg(not(feature = "kafka"))]
-        let subscription = EmptySubscription;
+        let subscription = async_graphql::EmptySubscription;
 
         let schema =
             Schema::build(AlarmsQueries, AlarmsMutations, subscription)

--- a/src/graphql/alarms/mod.rs
+++ b/src/graphql/alarms/mod.rs
@@ -6,9 +6,13 @@ use crate::{
     g_rpc::{alarms_db, alarms_svc},
     graphql::alarms::types::Alarm,
 };
-use async_graphql::{Error, Object, Subscription};
+#[cfg(feature = "kafka")]
+use async_graphql::Subscription;
+use async_graphql::{Error, Object};
 use chrono::{DateTime, Utc};
+#[cfg(feature = "kafka")]
 use rust_pubsub_lib::{KafkaSubscriber, StringMessage, Subscriber};
+#[cfg(feature = "kafka")]
 use tokio_stream::{Stream, StreamExt};
 use tonic::{Code, Status};
 use tracing::error;
@@ -188,18 +192,21 @@ impl AlarmsQueries {
 }
 
 /// Describes long-lived data streams for alarms.
+#[cfg(feature = "kafka")]
 #[derive(Default)]
 pub struct AlarmsSubscriptions {
     host: String,
     topic: String,
 }
 
+#[cfg(feature = "kafka")]
 impl AlarmsSubscriptions {
     pub fn new(host: String, topic: String) -> Self {
         Self { host, topic }
     }
 }
 
+#[cfg(feature = "kafka")]
 #[Subscription]
 impl AlarmsSubscriptions {
     /// Streams back all alarms from the alarms topic.
@@ -232,26 +239,33 @@ fn handle_error<T>(e: Status, gerund: &str) -> Result<T, Error> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "kafka")]
     use std::time::Duration;
 
-    use async_graphql::Schema;
+    use async_graphql::{EmptySubscription, Schema};
+    #[cfg(feature = "kafka")]
     use rust_pubsub_lib::{
         KafkaPublisher, KafkaTestHarness, Message, Publisher,
     };
+    #[cfg(feature = "kafka")]
     use serde_json::json;
+    #[cfg(feature = "kafka")]
     use tokio::time::timeout;
 
+    #[cfg(feature = "kafka")]
     use crate::g_rpc::proto::common::alarm::status::{Severity, Source, State};
 
     use super::*;
 
     async fn test_query_returns_err(gql_query: &str, err_msg: &str) {
-        let schema = Schema::build(
-            AlarmsQueries,
-            AlarmsMutations,
-            AlarmsSubscriptions::default(),
-        )
-        .finish();
+        #[cfg(feature = "kafka")]
+        let subscription = AlarmsSubscriptions::default();
+        #[cfg(not(feature = "kafka"))]
+        let subscription = EmptySubscription;
+
+        let schema =
+            Schema::build(AlarmsQueries, AlarmsMutations, subscription)
+                .finish();
         let result = schema.execute(gql_query).await;
         let err = result.errors.first().unwrap();
         println!("{err}");
@@ -468,6 +482,7 @@ mod tests {
         .await;
     }
 
+    #[cfg(feature = "kafka")]
     #[tokio::test]
     async fn alarms_subscription_integration_test() {
         let (harness, topic) = KafkaTestHarness::with_new_topic("alarms").await;

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -138,14 +138,15 @@ fn create_alarms_router() -> Router {
                 .subscription_endpoint(S_ENDPOINT)
                 .finish(),
         );
-        return Router::new()
+
+        Router::new()
             .route(
                 Q_ENDPOINT,
                 get(graphiql)
                     .post(graphql_handler)
                     .with_state(schema.clone()),
             )
-            .route_service(S_ENDPOINT, GraphQLSubscription::new(schema));
+            .route_service(S_ENDPOINT, GraphQLSubscription::new(schema))
     }
 
     #[cfg(not(feature = "kafka"))]

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -18,6 +18,7 @@ use axum::{
     routing::get,
 };
 use http::{Method, header};
+#[cfg(feature = "kafka")]
 use rust_env_var_lib::env_var;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use tower_http::cors::{Any, CorsLayer};
@@ -117,28 +118,56 @@ async fn create_acsys_router() -> Router {
 
 fn create_alarms_router() -> Router {
     const Q_ENDPOINT: &str = "/alarms";
-    const S_ENDPOINT: &str = "/alarms/s";
 
-    let schema = Schema::build(
-        alarms::AlarmsQueries,
-        alarms::AlarmsMutations,
-        alarms::AlarmsSubscriptions::new(get_alarms_host(), get_alarms_topic()),
-    )
-    .finish();
-    let graphiql = axum::response::Html(
-        async_graphql::http::GraphiQLSource::build()
-            .endpoint(Q_ENDPOINT)
-            .subscription_endpoint(S_ENDPOINT)
-            .finish(),
-    );
-    Router::new()
-        .route(
+    #[cfg(feature = "kafka")]
+    {
+        const S_ENDPOINT: &str = "/alarms/s";
+
+        let schema = Schema::build(
+            alarms::AlarmsQueries,
+            alarms::AlarmsMutations,
+            alarms::AlarmsSubscriptions::new(
+                get_alarms_host(),
+                get_alarms_topic(),
+            ),
+        )
+        .finish();
+        let graphiql = axum::response::Html(
+            async_graphql::http::GraphiQLSource::build()
+                .endpoint(Q_ENDPOINT)
+                .subscription_endpoint(S_ENDPOINT)
+                .finish(),
+        );
+        return Router::new()
+            .route(
+                Q_ENDPOINT,
+                get(graphiql)
+                    .post(graphql_handler)
+                    .with_state(schema.clone()),
+            )
+            .route_service(S_ENDPOINT, GraphQLSubscription::new(schema));
+    }
+
+    #[cfg(not(feature = "kafka"))]
+    {
+        let schema = Schema::build(
+            alarms::AlarmsQueries,
+            alarms::AlarmsMutations,
+            EmptySubscription,
+        )
+        .finish();
+        let graphiql = axum::response::Html(
+            async_graphql::http::GraphiQLSource::build()
+                .endpoint(Q_ENDPOINT)
+                .finish(),
+        );
+        Router::new().route(
             Q_ENDPOINT,
             get(graphiql)
                 .post(graphql_handler)
                 .with_state(schema.clone()),
         )
-        .route_service(S_ENDPOINT, GraphQLSubscription::new(schema))
+    }
 }
 
 // Creates the portion of the site map that handles the Beam Budget
@@ -319,12 +348,16 @@ pub async fn start_service(port: u16) {
         .unwrap();
 }
 
+#[cfg(feature = "kafka")]
 const ALARMS_KAFKA_HOST: &str = "ALARMS_KAFKA_HOST";
+#[cfg(feature = "kafka")]
 fn get_alarms_host() -> String {
     env_var::expect(ALARMS_KAFKA_HOST)
 }
 
+#[cfg(feature = "kafka")]
 const ALARMS_KAFKA_TOPIC: &str = "ALARMS_KAFKA_TOPIC";
+#[cfg(feature = "kafka")]
 fn get_alarms_topic() -> String {
     env_var::expect(ALARMS_KAFKA_TOPIC)
 }


### PR DESCRIPTION
In the last few iterations, some bugs crept in. This PR will close these bugs.

## PENDs While Monitoring PVs

Monitoring PVs resulted in only DPM PENDs. @charlieking65 says that DPM will always return an initial DPM PEND while it searches for the PV. After that, the PV data will be streamed. This service, however, got "stuck" on the status and never returned data (for PVs.)

A unit test was added to verify the bug and now the test passes.

## Settings always return `[17 -17]`

Even with a valid JWT, the setting API is always returning an authorization error.

It's now working. I was sending my JWT with "Bearer JWT".