### PR TITLE
Fix data filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -436,9 +436,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "extapi-acsys"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2121,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2470,15 +2470,15 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2504,9 +2504,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2514,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2565,9 +2565,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2663,9 +2663,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",
@@ -2747,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3045,9 +3045,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extapi-acsys"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 
 [features]

--- a/src/g_rpc/dpm/mod.rs
+++ b/src/g_rpc/dpm/mod.rs
@@ -19,7 +19,22 @@ type _TonicQueryResult<T> = Result<T, tonic::Status>;
 // same connection.
 
 pub async fn build_connection() -> Result<Connection, Error> {
-    const HOSTS: [&str; 1] = ["http://dce15:50051"];
+    const HOSTS: [&str; 14] = [
+        "http://dce01:50051",
+        "http://dce02:50051",
+        "http://dce03:50051",
+        "http://dce04:50051",
+        "http://dce05:50051",
+        "http://dce06:50051",
+        "http://dce07:50051",
+        "http://dce08:50051",
+        "http://dce09:50051",
+        "http://dce10:50051",
+        "http://dce11:50051",
+        "http://dce12:50051",
+        "http://dce13:50051",
+        "http://dce14:50051",
+    ];
 
     let endpoints = HOSTS.iter().map(|h| Endpoint::from_static(h));
     let channel = Channel::balance_list(endpoints);

--- a/src/graphql/acsys/datastream/datamerge.rs
+++ b/src/graphql/acsys/datastream/datamerge.rs
@@ -56,49 +56,56 @@ where
         }
     }
 
-    /// Filters out data points that have already been seen based on the
-    /// `latest` timestamp and updates `latest` with the newest timestamp in
-    /// the batch. Returns true if there is data left to emit.
+    /// Consumes an iterator of data points, filters out stale entries, and
+    /// returns the surviving items as a `Vec`. Updates `latest` with the
+    /// highest real-data timestamp seen.
     ///
-    /// Status replies are passed through without updating the `latest`
-    /// watermark. Their timestamps are synthetic (wall-clock `now()`) and
-    /// have no relation to the device's actual data timeline; advancing
-    /// `latest` past them would cause subsequent real data points -- whose
-    /// hardware timestamps predate the synthetic one -- to be silently
-    /// discarded.
+    /// The single pass applies these rules to each item in order:
+    ///
+    /// - **Stale data** (`timestamp <= latest`): silently discarded.
+    /// - **Fatal status** (negative `status`): emitted, watermark advanced to
+    ///   its timestamp, iteration stops — everything after it is dropped.
+    /// - **Warning status** (positive `status`): emitted as-is; the watermark
+    ///   is NOT advanced because the timestamp is a synthetic wall-clock value
+    ///   unrelated to the device's data timeline.
+    /// - **Normal data**: emitted and the watermark is advanced.
     fn filter_and_update_latest(
-        data: &mut Vec<global::DataInfo>, latest: &mut f64,
-    ) -> bool {
-        if data.is_empty() {
-            return false;
-        }
+        iter: impl Iterator<Item = global::DataInfo>, latest: &mut f64,
+    ) -> Vec<global::DataInfo> {
+        let mut done = false;
 
-        // If this packet is a single status reply, pass it through without
-        // touching the timestamp watermark.
-
-        if let [
-            global::DataInfo {
-                result: global::DataType::StatusReply(_),
-                ..
-            },
-        ] = data.as_slice()
-        {
-            return true;
-        }
-
-        let start = data.partition_point(|info| info.timestamp <= *latest);
-
-        // Remember the latest timestamp we've seen.
-
-        *latest = (*latest).max(data.last().unwrap().timestamp);
-
-        // Throw away any data points we've already seen.
-
-        if start > 0 {
-            data.drain(0..start);
-        }
-
-        !data.is_empty()
+        iter.scan(&mut *latest, |watermark, item| {
+            if done {
+                return None;
+            }
+            match &item.result {
+                global::DataType::StatusReply(global::StatusReply {
+                    status,
+                }) if *status < 0 => {
+                    // Fatal: emit, advance watermark, stop.
+                    **watermark = watermark.max(item.timestamp);
+                    done = true;
+                    Some(Some(item))
+                }
+                global::DataType::StatusReply(global::StatusReply {
+                    status,
+                }) if *status > 0 => {
+                    // Warning: emit without touching the watermark.
+                    Some(Some(item))
+                }
+                _ if item.timestamp <= **watermark => {
+                    // Stale: discard.
+                    Some(None)
+                }
+                _ => {
+                    // Normal data: emit and advance watermark.
+                    **watermark = watermark.max(item.timestamp);
+                    Some(Some(item))
+                }
+            }
+        })
+        .flatten()
+        .collect()
     }
 }
 
@@ -125,13 +132,17 @@ where
                             .entry(ref_id)
                             .or_insert_with(|| (DataChannel::new(), 0.0));
 
-                        if let Some(mut data) = chan.process_archive_data(data)
-                            && Self::filter_and_update_latest(&mut data, latest)
-                        {
-                            return Poll::Ready(Some(global::DataReply {
-                                ref_id,
-                                data,
-                            }));
+                        if let Some(raw) = chan.process_archive_data(data) {
+                            let data = Self::filter_and_update_latest(
+                                raw.into_iter(),
+                                latest,
+                            );
+                            if !data.is_empty() {
+                                return Poll::Ready(Some(global::DataReply {
+                                    ref_id,
+                                    data,
+                                }));
+                            }
                         }
                         continue;
                     }
@@ -154,10 +165,12 @@ where
                             .process_live_data(data, this.archived.is_none())
                         {
                             BufferResult::Data(None) => {}
-                            BufferResult::Data(Some(mut data)) => {
-                                if Self::filter_and_update_latest(
-                                    &mut data, latest,
-                                ) {
+                            BufferResult::Data(Some(raw)) => {
+                                let data = Self::filter_and_update_latest(
+                                    raw.into_iter(),
+                                    latest,
+                                );
+                                if !data.is_empty() {
                                     return Poll::Ready(Some(
                                         global::DataReply { ref_id, data },
                                     ));
@@ -187,16 +200,17 @@ where
                 if let Some(&ref_id) = this.pending.keys().next() {
                     let (mut chan, mut latest) =
                         this.pending.remove(&ref_id).unwrap();
-                    if let Some(mut data) = chan.get_buffer()
-                        && Self::filter_and_update_latest(
-                            &mut data,
+                    if let Some(raw) = chan.get_buffer() {
+                        let data = Self::filter_and_update_latest(
+                            raw.into_iter(),
                             &mut latest,
-                        )
-                    {
-                        return Poll::Ready(Some(global::DataReply {
-                            ref_id,
-                            data,
-                        }));
+                        );
+                        if !data.is_empty() {
+                            return Poll::Ready(Some(global::DataReply {
+                                ref_id,
+                                data,
+                            }));
+                        }
                     }
                     continue;
                 }
@@ -221,7 +235,7 @@ mod test {
         }
     }
 
-    fn status_info(ts: f64) -> global::DataInfo {
+    fn bad_status_info(ts: f64) -> global::DataInfo {
         global::DataInfo {
             timestamp: ts,
             result: global::DataType::StatusReply(global::StatusReply {
@@ -230,32 +244,43 @@ mod test {
         }
     }
 
+    fn warn_status_info(ts: f64) -> global::DataInfo {
+        global::DataInfo {
+            timestamp: ts,
+            result: global::DataType::StatusReply(global::StatusReply {
+                status: 1,
+            }),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // filter_and_update_latest unit tests (white-box)
 
-    // An empty vec returns false and leaves `latest` unchanged.
+    type DM = DataMerge<
+        futures::stream::Empty<global::DataReply>,
+        futures::stream::Empty<global::DataReply>,
+    >;
+
+    fn filter(
+        input: Vec<global::DataInfo>, latest: &mut f64,
+    ) -> Vec<global::DataInfo> {
+        DM::filter_and_update_latest(input.into_iter(), latest)
+    }
+
+    // An empty vec returns an empty vec and leaves `latest` unchanged.
     #[test]
     fn test_filter_empty_vec_returns_false() {
         let mut latest = 0.0_f64;
-        let mut data: Vec<global::DataInfo> = vec![];
-
-        assert!(!DataMerge::<
-            futures::stream::Empty<_>,
-            futures::stream::Empty<_>,
-        >::filter_and_update_latest(&mut data, &mut latest));
+        assert!(filter(vec![], &mut latest).is_empty());
         assert_eq!(latest, 0.0);
     }
 
-    // All data points are at or below the watermark → all filtered, returns false.
+    // All data points are at or below the watermark → all filtered, empty vec.
     #[test]
     fn test_filter_all_duplicates_returns_false() {
         let mut latest = 110.0_f64;
-        let mut data = vec![data_info(100.0), data_info(110.0)];
-
-        assert!(!DataMerge::<
-            futures::stream::Empty<_>,
-            futures::stream::Empty<_>,
-        >::filter_and_update_latest(&mut data, &mut latest));
+        let data =
+            filter(vec![data_info(100.0), data_info(110.0)], &mut latest);
         assert!(data.is_empty());
         // latest must not regress
         assert_eq!(latest, 110.0);
@@ -265,13 +290,10 @@ mod test {
     #[test]
     fn test_filter_partial_dedupe() {
         let mut latest = 105.0_f64;
-        let mut data =
-            vec![data_info(100.0), data_info(105.0), data_info(110.0)];
-
-        assert!(DataMerge::<
-            futures::stream::Empty<_>,
-            futures::stream::Empty<_>,
-        >::filter_and_update_latest(&mut data, &mut latest));
+        let data = filter(
+            vec![data_info(100.0), data_info(105.0), data_info(110.0)],
+            &mut latest,
+        );
         assert_eq!(data, vec![data_info(110.0)]);
         assert_eq!(latest, 110.0);
     }
@@ -280,12 +302,10 @@ mod test {
     #[test]
     fn test_filter_no_duplicates_advances_watermark() {
         let mut latest = 50.0_f64;
-        let mut data = vec![data_info(60.0), data_info(70.0), data_info(80.0)];
-
-        assert!(DataMerge::<
-            futures::stream::Empty<_>,
-            futures::stream::Empty<_>,
-        >::filter_and_update_latest(&mut data, &mut latest));
+        let data = filter(
+            vec![data_info(60.0), data_info(70.0), data_info(80.0)],
+            &mut latest,
+        );
         assert_eq!(
             data,
             vec![data_info(60.0), data_info(70.0), data_info(80.0)]
@@ -298,33 +318,55 @@ mod test {
     #[test]
     fn test_filter_status_reply_passes_through_without_advancing_watermark() {
         let mut latest = 50.0_f64;
-        let mut data = vec![status_info(1000.0)];
-
-        assert!(DataMerge::<
-            futures::stream::Empty<_>,
-            futures::stream::Empty<_>,
-        >::filter_and_update_latest(&mut data, &mut latest));
+        let data = filter(vec![bad_status_info(1000.0)], &mut latest);
         // Status must be preserved.
-        assert_eq!(data, vec![status_info(1000.0)]);
+        assert_eq!(data, vec![bad_status_info(1000.0)]);
         // Watermark must NOT have advanced.
-        assert_eq!(latest, 50.0);
+        assert_eq!(latest, 1000.0);
     }
 
     // A multi-element packet that happens to contain a status reply is NOT
     // treated as a pure status packet — the normal timestamp path applies.
     #[test]
     fn test_filter_multi_element_with_status_uses_normal_path() {
-        let mut latest = 0.0_f64;
-        let mut data = vec![status_info(1000.0), data_info(10.0)];
-
-        assert!(DataMerge::<
-            futures::stream::Empty<_>,
-            futures::stream::Empty<_>,
-        >::filter_and_update_latest(&mut data, &mut latest));
-        // Both elements survive (both are above the watermark of 0.0).
-        assert_eq!(data, vec![status_info(1000.0), data_info(10.0)]);
-        // Watermark advances to the last element's timestamp.
-        assert_eq!(latest, 10.0);
+        {
+            let mut latest = 0.0_f64;
+            let data = filter(
+                vec![
+                    data_info(100.0),
+                    bad_status_info(1000.0),
+                    data_info(200.0),
+                ],
+                &mut latest,
+            );
+            // data_info(100.0) and bad_status_info(1000.0) survive; fatal
+            // status truncates data_info(200.0).
+            assert_eq!(data, vec![data_info(100.0), bad_status_info(1000.0)]);
+            // Watermark advances to the fatal status's timestamp.
+            assert_eq!(latest, 1000.0);
+        }
+        {
+            let mut latest = 0.0_f64;
+            let data = filter(
+                vec![
+                    data_info(100.0),
+                    warn_status_info(1000.0),
+                    data_info(200.0),
+                ],
+                &mut latest,
+            );
+            // All three survive; warning status does not truncate.
+            assert_eq!(
+                data,
+                vec![
+                    data_info(100.0),
+                    warn_status_info(1000.0),
+                    data_info(200.0)
+                ]
+            );
+            // Watermark advances to the last real data point, not the warning.
+            assert_eq!(latest, 200.0);
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -696,7 +738,7 @@ mod test {
         let live_input = [
             global::DataReply {
                 ref_id: 0,
-                data: vec![status_info(1000.0)], // synthetic "now()" timestamp
+                data: vec![warn_status_info(1000.0)], // synthetic "now()" timestamp
             },
             global::DataReply {
                 ref_id: 0,
@@ -712,7 +754,7 @@ mod test {
         // The status reply must come through.
         let r = s.next().await.unwrap();
         assert_eq!(r.ref_id, 0);
-        assert_eq!(r.data, vec![status_info(1000.0)]);
+        assert_eq!(r.data, vec![warn_status_info(1000.0)]);
 
         // The real data must NOT be swallowed by the watermark.
         let r = s.next().await.unwrap();
@@ -790,6 +832,30 @@ mod test {
         assert_eq!(r.data, vec![data_info(300.0)]);
 
         assert!(s.next().await.is_none());
+    }
+
+    // An earlier version of the filtering function used
+    // `.partition_point()` which uses a binary search and,
+    // therefore, requires the data to be in strict ascending order.
+    // The timestamps, however, are not guaranteed to be sorted.
+    // This test ensures that the filtering function does not rely
+    // on sorted data and correctly filters out stale points even
+    // when the input is unsorted.
+    #[test]
+    fn test_filter_unsorted_stale_point_is_removed() {
+        let mut latest = 60.0_f64;
+        let data = filter(
+            vec![
+                data_info(30.0),
+                data_info(100.0),
+                data_info(50.0),
+                data_info(110.0),
+            ],
+            &mut latest,
+        );
+        // 30.0 and 50.0 are both ≤ 60.0 and must be filtered.
+        assert_eq!(data, vec![data_info(100.0), data_info(110.0)]);
+        assert_eq!(latest, 110.0);
     }
 
     // An archive stream that closes naturally (no sentinel) with no live


### PR DESCRIPTION
The function that filters the stream of data mostly worked but had a code path that was buggy. This function processes the stream of incoming device readings and filters out data points whose timestamp is earlier than the latest seen. We need this feature to support the seamless switch from archived data to live data because the "now" point may get data from both sources.

When DPM returns DPM_PEND, it adds its own timestamp which may be greater than the timestamp that gets returned in the first point.

So the filter function was adjusted so that if we get an ACNET warning status, the "latest timestamp" doesn't get updated.